### PR TITLE
Enable JXL support in linux builds

### DIFF
--- a/build/patches/00Add-support-to-jxl.patch
+++ b/build/patches/00Add-support-to-jxl.patch
@@ -320,7 +320,7 @@ diff --git a/media/media_options.gni b/media/media_options.gni
    enable_av1_decoder = enable_dav1d_decoder
  
 +  # If true, adds support for JPEG XL image decoding.
-+  enable_jxl_decoder = is_android || is_win
++  enable_jxl_decoder = is_android || is_win || is_lin
 +
    # Enable HEVC/H265 demuxing. Actual decoding must be provided by the
    # platform. Always enable this for Lacros, it determines support at runtime.


### PR DESCRIPTION
## Description

I propose to add JXL support for linux builds; the recently released linux build doesn't support it.
Unfortunately I don't know how to make a test build, so I'm not sure if it builds correctly.

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] Bromite can be built with these changes
* [ ] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [ ] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
