### PR TITLE
Enable platform aac hevc

### DIFF
--- a/build/cromite.gn_args
+++ b/build/cromite.gn_args
@@ -37,13 +37,41 @@ enable_feed_v2=false
 enable_cardboard=false
 is_high_end_android=true
 
+# media section
 proprietary_codecs=true
 ffmpeg_branding="Chrome"
 enable_av1_decoder=true
 enable_dav1d_decoder=true
-enable_platform_dolby_vision=true
-enable_platform_hevc=true
-enable_mse_mpeg2ts_stream_parser=true
+
+# disable cisco OpenH264
+media_use_openh264 = false
+
+# decoder flags
+if (target_os == "android" || target_os == "win") {
+  # codec supported by default
+  # android: https://developer.android.com/media/platform/supported-formats
+  # windows: https://learn.microsoft.com/en-us/windows/win32/medfound/codecobjects
+
+  # enable aac and h264 hw decoder only
+  enable_platform_aac_audio = true
+  enable_platform_h264_video = true
+
+  # enable hw decoder for h265 (hevc)
+  enable_platform_hevc = true
+
+  # disable dolby vision
+  enable_platform_dolby_vision = false
+  enable_platform_encrypted_dolby_vision = false
+
+  if (target_os == "win") {
+    # enable ac3/eac codec
+    enable_platform_ac3_eac3_audio = true
+  }
+}
+
+# disable passthrough audio codecs
+enable_platform_dts_audio = false
+enable_passthrough_audio_codecs = false
 
 # Do not compile libmonochrome.so with RELR relocations
 # since supported only on API 28+

--- a/build/cromite_patches_list.txt
+++ b/build/cromite_patches_list.txt
@@ -282,6 +282,7 @@ Disable-Compose-feature.patch
 Disable-offline-autofetch-flag.patch
 Enable-percent-based-scrolling-on-Windows.patch
 Show-NTP-at-startup.patch
+Enable-platform-aac-audio-and-h264-video.patch
 
 Temp-PerformanceNavigationTiming-privacy-fix.patch
 Temp-disable-predictive-back-gesture.patch

--- a/build/patches/Disable-omission-of-URL-elements-in-Omnibox.patch
+++ b/build/patches/Disable-omission-of-URL-elements-in-Omnibox.patch
@@ -52,5 +52,5 @@ new file mode 100755
 --- /dev/null
 +++ b/cromite_flags/chrome/browser/flags/android/chrome_feature_list_cc/disable-omission-of-URL-elements-in-Omnibox.inc
 @@ -0,0 +1 @@
-+SET_CROMITE_FEATURE_DISABLED(kAndroidVisibleUrlTruncation);
++SET_CROMITE_FEATURE_DISABLED(kAndroidVisibleUrlTruncationV2);
 --

--- a/build/patches/Enable-platform-aac-audio-and-h264-video.patch
+++ b/build/patches/Enable-platform-aac-audio-and-h264-video.patch
@@ -1,0 +1,228 @@
+From: uazo <uazo@users.noreply.github.com>
+Date: Wed, 6 Mar 2024 12:05:52 +0000
+Subject: Enable platform aac audio and h264 video
+
+License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
+---
+ media/BUILD.gn                                      |  2 ++
+ .../src/org/chromium/media/AudioManagerAndroid.java |  2 ++
+ media/base/android/media_codec_util.cc              |  4 ++++
+ media/base/win/mf_helpers.cc                        |  5 +++++
+ media/filters/ffmpeg_audio_decoder.cc               | 10 ++++++++++
+ media/filters/ffmpeg_demuxer.cc                     |  1 +
+ media/filters/ffmpeg_video_decoder.cc               | 11 +++++++++++
+ media/filters/win/media_foundation_audio_decoder.cc |  9 +++++++++
+ media/gpu/windows/supported_profile_helpers.cc      | 13 ++++++++++++-
+ media/media_options.gni                             |  8 ++++++++
+ 10 files changed, 64 insertions(+), 1 deletion(-)
+
+diff --git a/media/BUILD.gn b/media/BUILD.gn
+--- a/media/BUILD.gn
++++ b/media/BUILD.gn
+@@ -29,6 +29,8 @@ buildflag_header("media_buildflags") {
+       enable_platform_dts_audio && (is_win || is_linux)
+ 
+   flags = [
++    "ENABLE_PLATFORM_AAC_AUDIO=$enable_platform_aac_audio",
++    "ENABLE_PLATFORM_H264_VIDEO=$enable_platform_h264_video",
+     "ALLOW_OOP_VIDEO_DECODER=$allow_oop_video_decoder",
+     "ALLOW_HOSTING_OOP_VIDEO_DECODER=$allow_hosting_oop_video_decoder",
+     "ALTERNATE_CDM_STORAGE_ID_KEY=\"$alternate_cdm_storage_id_key\"",
+diff --git a/media/base/android/java/src/org/chromium/media/AudioManagerAndroid.java b/media/base/android/java/src/org/chromium/media/AudioManagerAndroid.java
+--- a/media/base/android/java/src/org/chromium/media/AudioManagerAndroid.java
++++ b/media/base/android/java/src/org/chromium/media/AudioManagerAndroid.java
+@@ -562,6 +562,8 @@ class AudioManagerAndroid {
+                             break;
+                     }
+                 }
++                // only PCM_LINEAR allowed via hdmi in cromite
++                mask &= AudioEncodingFormat.PCM_LINEAR;
+ 
+                 // Require all devices to support a format
+                 if (first) {
+diff --git a/media/base/android/media_codec_util.cc b/media/base/android/media_codec_util.cc
+--- a/media/base/android/media_codec_util.cc
++++ b/media/base/android/media_codec_util.cc
+@@ -15,6 +15,7 @@
+ #include "base/containers/contains.h"
+ #include "base/logging.h"
+ #include "base/strings/string_util.h"
++#include "media/media_buildflags.h"
+ #include "media/base/android/media_codec_bridge.h"
+ #include "media/base/android/media_jni_headers/CodecProfileLevelList_jni.h"
+ #include "media/base/android/media_jni_headers/MediaCodecUtil_jni.h"
+@@ -113,6 +114,9 @@ std::string MediaCodecUtil::CodecToAndroidMimeType(AudioCodec codec) {
+ // static
+ std::string MediaCodecUtil::CodecToAndroidMimeType(AudioCodec codec,
+                                                    SampleFormat sample_format) {
++#if BUILDFLAG(ENABLE_PLATFORM_AAC_AUDIO)
++  if (codec == AudioCodec::kAAC) return kAacMimeType;
++#endif
+   // Passthrough is possible for some bitstream formats.
+   const bool is_passthrough = sample_format == kSampleFormatDts ||
+                               sample_format == kSampleFormatDtsxP2 ||
+diff --git a/media/base/win/mf_helpers.cc b/media/base/win/mf_helpers.cc
+--- a/media/base/win/mf_helpers.cc
++++ b/media/base/win/mf_helpers.cc
+@@ -17,6 +17,7 @@
+ #include "base/check_op.h"
+ #include "base/win/scoped_co_mem.h"
+ #include "base/win/windows_version.h"
++#include "media/media_buildflags.h"
+ #include "media/base/audio_codecs.h"
+ #include "media/base/audio_decoder_config.h"
+ #include "media/base/win/mf_helpers.h"
+@@ -452,7 +453,11 @@ HRESULT GetAacAudioType(const AudioDecoderConfig& decoder_config,
+ 
+   size_t extra_size = wave_format_size - sizeof(WAVEFORMATEX);
+   aac_wave_format->wfx.cbSize = static_cast<WORD>(extra_size);
++#if BUILDFLAG(ENABLE_PLATFORM_AAC_AUDIO)
++  aac_wave_format->wPayloadType = 1;  // Audio Data Transport Stream (ADTS)
++#else
+   aac_wave_format->wPayloadType = 0;  // RAW AAC
++#endif
+   aac_wave_format->wAudioProfileLevelIndication =
+       0xFE;                          // no audio profile specified
+   aac_wave_format->wStructType = 0;  // audio specific config follows
+diff --git a/media/filters/ffmpeg_audio_decoder.cc b/media/filters/ffmpeg_audio_decoder.cc
+--- a/media/filters/ffmpeg_audio_decoder.cc
++++ b/media/filters/ffmpeg_audio_decoder.cc
+@@ -91,6 +91,16 @@ void FFmpegAudioDecoder::Initialize(const AudioDecoderConfig& config,
+     return;
+   }
+ 
++#if BUILDFLAG(ENABLE_PLATFORM_AAC_AUDIO)
++  if (config.codec() == AudioCodec::kAAC) {
++    std::move(bound_init_cb)
++        .Run(DecoderStatus(DecoderStatus::Codes::kUnsupportedProfile)
++                 .WithData("decoder", "FFmpegAudioDecoder")
++                 .WithData("profile", config.profile()));
++    return;
++  }
++#endif
++
+   // TODO(dalecurtis): Remove this if ffmpeg ever gets xHE-AAC support.
+   if (config.profile() == AudioCodecProfile::kXHE_AAC) {
+     std::move(bound_init_cb)
+diff --git a/media/filters/ffmpeg_demuxer.cc b/media/filters/ffmpeg_demuxer.cc
+--- a/media/filters/ffmpeg_demuxer.cc
++++ b/media/filters/ffmpeg_demuxer.cc
+@@ -791,6 +791,7 @@ void FFmpegDemuxerStream::InitBitstreamConverter() {
+       // FFmpeg doesn't understand xHE-AAC profiles yet, which can't be put in
+       // ADTS anyways, so skip bitstream conversion when the profile is
+       // unknown.
++      // Also Windows need ADTS conversion for AAC
+       if (audio_config_->profile() != AudioCodecProfile::kXHE_AAC) {
+         bitstream_converter_ =
+             std::make_unique<FFmpegAACBitstreamConverter>(stream_->codecpar);
+diff --git a/media/filters/ffmpeg_video_decoder.cc b/media/filters/ffmpeg_video_decoder.cc
+--- a/media/filters/ffmpeg_video_decoder.cc
++++ b/media/filters/ffmpeg_video_decoder.cc
+@@ -17,6 +17,7 @@
+ #include "base/memory/raw_ptr.h"
+ #include "base/task/bind_post_task.h"
+ #include "base/task/sequenced_task_runner.h"
++#include "media/media_buildflags.h"
+ #include "media/base/decoder_buffer.h"
+ #include "media/base/limits.h"
+ #include "media/base/media_log.h"
+@@ -137,6 +138,16 @@ bool FFmpegVideoDecoder::IsCodecSupported(VideoCodec codec) {
+     return false;
+   }
+ #endif
++#if BUILDFLAG(ENABLE_PLATFORM_H264_VIDEO)
++  if (codec == VideoCodec::kH264) {
++    return false;
++  }
++#endif
++#if BUILDFLAG(ENABLE_PLATFORM_HEVC)
++  if (codec == VideoCodec::kHEVC) {
++    return false;
++  }
++#endif
+ 
+   return avcodec_find_decoder(VideoCodecToCodecID(codec)) != nullptr;
+ }
+diff --git a/media/filters/win/media_foundation_audio_decoder.cc b/media/filters/win/media_foundation_audio_decoder.cc
+--- a/media/filters/win/media_foundation_audio_decoder.cc
++++ b/media/filters/win/media_foundation_audio_decoder.cc
+@@ -96,11 +96,15 @@ absl::optional<MFT_REGISTER_TYPE_INFO> GetTypeInfo(
+ #endif
+ #if BUILDFLAG(USE_PROPRIETARY_CODECS)
+     case AudioCodec::kAAC:
++#if BUILDFLAG(ENABLE_PLATFORM_AAC_AUDIO)
++      return MFT_REGISTER_TYPE_INFO{MFMediaType_Audio, MFAudioFormat_AAC};
++#else
+       if (config.profile() == AudioCodecProfile::kXHE_AAC &&
+           base::win::GetVersion() >= base::win::Version::WIN11_22H2) {
+         return MFT_REGISTER_TYPE_INFO{MFMediaType_Audio, MFAudioFormat_AAC};
+       }
+       [[fallthrough]];
++#endif // BUILDFLAG(ENABLE_PLATFORM_AAC_AUDIO)
+ #endif
+ #if BUILDFLAG(ENABLE_PLATFORM_AC4_AUDIO)
+     case AudioCodec::kAC4:
+@@ -310,8 +314,13 @@ void MediaFoundationAudioDecoder::Reset(base::OnceClosure reset_cb) {
+ }
+ 
+ bool MediaFoundationAudioDecoder::NeedsBitstreamConversion() const {
++#if BUILDFLAG(ENABLE_PLATFORM_AAC_AUDIO)
++  // An AAC stream needs to be converted as ADTS stream.
++  return config_.codec() == AudioCodec::kAAC;
++#else
+   // DTS does not require any header/bit stream conversion
+   return false;
++#endif
+ }
+ 
+ bool MediaFoundationAudioDecoder::CreateDecoder() {
+diff --git a/media/gpu/windows/supported_profile_helpers.cc b/media/gpu/windows/supported_profile_helpers.cc
+--- a/media/gpu/windows/supported_profile_helpers.cc
++++ b/media/gpu/windows/supported_profile_helpers.cc
+@@ -173,7 +173,11 @@ SupportedResolutionRangeMap GetSupportedD3D11VideoDecoderResolutions(
+   //
+   // On Windows 7 the maximum resolution supported by media foundation is
+   // 1920 x 1088. We use 1088 to account for 16x16 macro-blocks.
++#if BUILDFLAG(ENABLE_PLATFORM_H264_VIDEO)
++  constexpr gfx::Size kDefaultMaxH264Resolution(4096, 2304);
++#else
+   constexpr gfx::Size kDefaultMaxH264Resolution(1920, 1088);
++#endif
+   SupportedResolutionRange h264_profile;
+   h264_profile.min_resolution = kMinResolution;
+   h264_profile.max_landscape_resolution = kDefaultMaxH264Resolution;
+@@ -181,7 +185,14 @@ SupportedResolutionRangeMap GetSupportedD3D11VideoDecoderResolutions(
+   // We don't have a way to map DXVA support to specific H.264 profiles, so just
+   // mark all the common ones with the same level of support.
+   constexpr VideoCodecProfile kSupportedH264Profiles[] = {
+-      H264PROFILE_BASELINE, H264PROFILE_MAIN, H264PROFILE_HIGH};
++      H264PROFILE_BASELINE, H264PROFILE_MAIN, H264PROFILE_HIGH
++#if BUILDFLAG(ENABLE_PLATFORM_H264_VIDEO)
++      // even if they are not supported, we add the items so that play
++      // is still attempted. On the contrary, non-support would appear immediately.
++      , H264PROFILE_HIGH10PROFILE, H264PROFILE_HIGH422PROFILE,
++      H264PROFILE_HIGH444PREDICTIVEPROFILE
++#endif
++  };
+   for (const auto profile : kSupportedH264Profiles)
+     supported_resolutions[profile] = h264_profile;
+ 
+diff --git a/media/media_options.gni b/media/media_options.gni
+--- a/media/media_options.gni
++++ b/media/media_options.gni
+@@ -56,6 +56,14 @@ declare_args() {
+     media_use_libvpx = false
+   }
+ 
++  # Enables AAC audio decoder using only MediaCodecAudioDecoder in Android
++  # and MediaFoundationAudioDecoder in Windows
++  enable_platform_aac_audio = false
++
++  # Enables h264 video decoder using only MediaCodecVideoDecoder in Android
++  # and D3D11VideoDecoder in Windows
++  enable_platform_h264_video = false
++
+   # Enable usage of OpenH264 within the media library. Used for software based
+   # encoding of H264 content.
+   media_use_openh264 = true
+--


### PR DESCRIPTION
## Description

Enable hardware aac and h264 codecs in android and windows

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [X] Cromite can be built with these changes
* [X] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [X] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [ ] patch description contains explanation of changes
* [X] no unnecessary whitespace or unrelated changes

fixes #710 