### PR TITLE
Add chrome-sandbox to the Linux x86_64 release workflow

### DIFF
--- a/.github/workflows/build_cromite.yaml
+++ b/.github/workflows/build_cromite.yaml
@@ -397,7 +397,7 @@ jobs:
           gn args out/lin64/ --list >out/lin64/gn_list
           echo "::endgroup::"
 
-          ninja -C out/lin64 chrome
+          ninja -C out/lin64 chrome chrome_sandbox
 
           cp ../../cromite/build/RELEASE out/lin64
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -162,6 +162,7 @@ jobs:
           echo "::group::-------- linux x64"
           mkdir chrome-lin/
           cp $OUTPUTFILE_LIN/chrome chrome-lin/
+          cp $OUTPUTFILE_LIN/chrome_sandbox chrome-lin/chrome-sandbox
           cp $OUTPUTFILE_LIN/chrome_100_percent.pak chrome-lin/
           cp $OUTPUTFILE_LIN/chrome_200_percent.pak chrome-lin/
           cp $OUTPUTFILE_LIN/chrome_crashpad_handler chrome-lin/


### PR DESCRIPTION
## Description

Adding the "chrome-sandbox" to the Linux x86_64 build and release workflows in preparation for the Linux Flatpak.

This will build the 320.7 kB binary which allows Chromium-based browsers to run properly in a sandbox (like Flatpak) on Linux.

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [x] Cromite can be built with these changes
* [x] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [ ] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
