### PR TITLE
CI: rework the patch-doc script and workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,15 @@
-[*.{yaml,sh,gn_args}]
-tab_width = 2
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
 indent_size = 2
-end_of_line = crlf
 indent_style = space
+insert_final_newline = true
+
+[*.sh]
+indent_size = 4
+indent_style = space
+
+[*.patch]
+insert_final_newline = false

--- a/.github/workflows/update-patches-doc.yaml
+++ b/.github/workflows/update-patches-doc.yaml
@@ -32,33 +32,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-
-      - name: "Get value from dispatch"
-        run: |
-          if [ -z "${RTAG}" ]; then
-            echo "RTAG=$GITHUB_SHA" >> $GITHUB_ENV
-            echo "RTAG=$RTAG"
-          fi
-
       - name: Checkout 'uazo/cromite' ${{ env.BRANCH }}
         uses: actions/checkout@v2
         with:
             repository: 'uazo/cromite'
             ref: ${{ github.event.inputs.rtag }}
-            path: 'cromite'
             fetch-depth: 1
 
       - name: Generate patches doc
         run: |
-          export HOME=$GITHUB_WORKSPACE
-
-          bash ~/cromite/tools/extract-all-patch-data.sh ~/cromite/build/patches
+          bash ./tools/extract-all-patch-data.sh ./build/patches
 
       - name: Check differences CHANGES=${{ env.CHANGES }}
         run: |
-          export HOME=$GITHUB_WORKSPACE
-
-          cd ~/cromite
           CHANGES=0 && git diff --quiet || CHANGES=1
           echo "CHANGES=$CHANGES" >> $GITHUB_ENV
 

--- a/tools/extract-all-patch-data.sh
+++ b/tools/extract-all-patch-data.sh
@@ -4,7 +4,7 @@ SCRIPT_FOLDER="$(realpath "$(dirname "$0")")"
 SCRIPT="$SCRIPT_FOLDER/extract-patch-data.sh"
 
 OUTPUT="$SCRIPT_FOLDER"/../docs/PATCHES.md
-test -f $OUTPUT && rm $OUTPUT
+rm -f "$OUTPUT"
 
 pushd "$1" >/dev/null
 

--- a/tools/extract-all-patch-data.sh
+++ b/tools/extract-all-patch-data.sh
@@ -9,10 +9,8 @@ rm -f "$OUTPUT"
 pushd "$1" >/dev/null
 
 for filename in *.patch; do
-    (echo "Filename: $filename"; cat "$filename") | bash "$SCRIPT" >>"$OUTPUT"
-done
-
-sort -k1 -t"|" -o $OUTPUT $OUTPUT
+    (echo "Filename: $filename"; cat "$filename") | bash "$SCRIPT"
+done | sort -k1 -t"|" -o "$OUTPUT"
 
 sed -i '1s/^/| Patch | Message |\n/' $OUTPUT
 sed -i '2s/^/|--------|--------|\n/' $OUTPUT

--- a/tools/extract-all-patch-data.sh
+++ b/tools/extract-all-patch-data.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
-FOLDER=$1
-SCRIPT_FOLDER="$(dirname "$0")"
+SCRIPT_FOLDER="$(realpath "$(dirname "$0")")"
+SCRIPT="$SCRIPT_FOLDER/extract-patch-data.sh"
 
 OUTPUT="$SCRIPT_FOLDER"/../docs/PATCHES.md
 test -f $OUTPUT && rm $OUTPUT
 
-for filename in "$FOLDER"/*.patch; do
-    bash $SCRIPT_FOLDER/extract-patch-data.sh $filename >>$OUTPUT
+pushd "$1" >/dev/null
+
+for filename in *.patch; do
+    (echo "Filename: $filename"; cat "$filename") | bash "$SCRIPT" >>"$OUTPUT"
 done
 
 sort -k1 -t"|" -o $OUTPUT $OUTPUT

--- a/tools/extract-all-patch-data.sh
+++ b/tools/extract-all-patch-data.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 SCRIPT_FOLDER="$(realpath "$(dirname "$0")")"
 SCRIPT="$SCRIPT_FOLDER/extract-patch-data.sh"
 

--- a/tools/extract-all-patch-data.sh
+++ b/tools/extract-all-patch-data.sh
@@ -3,7 +3,7 @@
 SCRIPT_FOLDER="$(realpath "$(dirname "$0")")"
 SCRIPT="$SCRIPT_FOLDER/extract-patch-data.sh"
 
-OUTPUT="$SCRIPT_FOLDER"/../docs/PATCHES.md
+OUTPUT="$SCRIPT_FOLDER/../docs/PATCHES.md"
 rm -f "$OUTPUT"
 
 pushd "$1" >/dev/null
@@ -12,5 +12,5 @@ for filename in *.patch; do
     (echo "Filename: $filename"; cat "$filename") | bash "$SCRIPT"
 done | sort -k1 -t"|" -o "$OUTPUT"
 
-sed -i '1s/^/| Patch | Message |\n/' $OUTPUT
-sed -i '2s/^/|--------|--------|\n/' $OUTPUT
+sed -i '1s/^/| Patch | Message |\n/' "$OUTPUT"
+sed -i '2s/^/|--------|--------|\n/' "$OUTPUT"

--- a/tools/extract-patch-data.sh
+++ b/tools/extract-patch-data.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-while read current_line
-do
+while read -r current_line; do
     if [[ $current_line =~ ^Filename:* ]]; then
         FILENAME=${current_line:9}
 
@@ -14,19 +13,19 @@ do
         DATE=${current_line:5}
 
     elif [[ $current_line =~ ^License:* ]]; then
-        LICENSE=`echo ${current_line:9} | cut -d ' ' -f1`
+        LICENSE=$(echo "${current_line:9}" | cut -d ' ' -f1)
 
     elif [[ $current_line =~ ^"Original License:"* ]]; then
         continue
 
     elif [[ $current_line =~ ^From:* ]]; then
-        FROM=`echo ${current_line:5} | cut -d ' ' -f1`
+        FROM=$(echo "${current_line:5}" | cut -d ' ' -f1)
 
     elif [[ $current_line =~ ^---* ]]; then
         break
 
-    elif [ ! -z "$current_line" ]; then
-        if [ ! -z "$MESSAGE" ]; then
+    elif [ -n "$current_line" ]; then
+        if [ -n  "$MESSAGE" ]; then
             MESSAGE+="<br>"
         fi
         MESSAGE+=$current_line

--- a/tools/extract-patch-data.sh
+++ b/tools/extract-patch-data.sh
@@ -15,17 +15,11 @@ do
     elif [[ $current_line =~ ^License:* ]]; then
         LICENSE=`echo ${current_line:9} | cut -d ' ' -f1`
 
-    elif [[ $current_line =~ ^Category:* ]]; then
-        CATEGORY=`echo ${current_line:9} | cut -d ' ' -f1`
-
     elif [[ $current_line =~ ^"Original License:"* ]]; then
         continue
 
     elif [[ $current_line =~ ^From:* ]]; then
         FROM=`echo ${current_line:5} | cut -d ' ' -f1`
-
-    elif [[ $current_line =~ ^Context:* ]]; then
-        CONTEXT=${current_line:8}
 
     elif [[ $current_line =~ ^---* ]]; then
         break
@@ -43,8 +37,6 @@ done
 # echo SUBJECT: $SUBJECT
 # echo DATE: $DATE
 # echo LICENSE: $LICENSE
-# echo CONTEXT: $CONTEXT
-# echo CATEGORY: $CATEGORY
 # echo -e MESSAGE: $MESSAGE
 
 SUBJECT=`echo $SUBJECT | xargs`
@@ -53,7 +45,6 @@ echo "|**$SUBJECT**" \
      "<br><sub><nobr>"$DATE"</nobr>" \
      "<br>File: [$(basename $PATCH)](/build/patches/$(basename $PATCH))" \
      "<br><nobr>Author: "$FROM"</nobr>" \
-     "<br><nobr>Context: "$CONTEXT"</nobr>" \
      "<br><nobr>License: "$LICENSE"</nobr>" \
      "|"$MESSAGE"|"
 )

--- a/tools/extract-patch-data.sh
+++ b/tools/extract-patch-data.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-CR=$(printf "\r")
-
 while read current_line
 do
     if [[ $current_line =~ ^Filename:* ]]; then
@@ -39,8 +37,6 @@ done
 # echo DATE: $DATE
 # echo LICENSE: $LICENSE
 # echo -e MESSAGE: $MESSAGE
-
-SUBJECT=`echo $SUBJECT | xargs`
 
 echo "|**$SUBJECT**" \
      "<br><sub><nobr>"$DATE"</nobr>" \

--- a/tools/extract-patch-data.sh
+++ b/tools/extract-patch-data.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-PATCH=$1
 CR=$(printf "\r")
 
-cat $PATCH | (
 while read current_line
 do
-    if [[ $current_line =~ ^Subject:* ]]; then
+    if [[ $current_line =~ ^Filename:* ]]; then
+        FILENAME=${current_line:9}
+
+    elif [[ $current_line =~ ^Subject:* ]]; then
         SUBJECT=${current_line:8}
 
     elif [[ $current_line =~ ^Date:* ]]; then
@@ -43,8 +44,7 @@ SUBJECT=`echo $SUBJECT | xargs`
 
 echo "|**$SUBJECT**" \
      "<br><sub><nobr>"$DATE"</nobr>" \
-     "<br>File: [$(basename $PATCH)](/build/patches/$(basename $PATCH))" \
+     "<br>File: [$FILENAME](/build/patches/$FILENAME)" \
      "<br><nobr>Author: "$FROM"</nobr>" \
      "<br><nobr>License: "$LICENSE"</nobr>" \
      "|"$MESSAGE"|"
-)

--- a/tools/extract-patch-data.sh
+++ b/tools/extract-patch-data.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 while read current_line
 do
     if [[ $current_line =~ ^Filename:* ]]; then

--- a/tools/extract-patch-data.sh
+++ b/tools/extract-patch-data.sh
@@ -39,8 +39,8 @@ done
 # echo -e MESSAGE: $MESSAGE
 
 echo "|**$SUBJECT**" \
-     "<br><sub><nobr>"$DATE"</nobr>" \
+     "<br><sub><nobr>$DATE</nobr>" \
      "<br>File: [$FILENAME](/build/patches/$FILENAME)" \
-     "<br><nobr>Author: "$FROM"</nobr>" \
-     "<br><nobr>License: "$LICENSE"</nobr>" \
-     "|"$MESSAGE"|"
+     "<br><nobr>Author: $FROM</nobr>" \
+     "<br><nobr>License: $LICENSE</nobr>" \
+     "|$MESSAGE|"


### PR DESCRIPTION
## Description

Been using Cromite for a while now, so decided to help out a bit. This PR tweaks the patch-doc scripts and workflow file. Follow-up PRs will resolve the rest - one at a time.

Although since my editor handles .editorconfig and complained, the first commit addresses that.

NOTE: I have smoked tested this locally on my machine and not in Github Actions. Hope I didn't break things too badly.

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] ~Bromite can be built with these changes~ NA
* [ ] ~I have tested that the new change works as intended (AVD or physical device will do)~ NA

### Format

* [ ] ~patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)~ NA
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
