### PR TITLE
Init support for trichrome builds

### DIFF
--- a/build/cromite_patches_list.txt
+++ b/build/cromite_patches_list.txt
@@ -319,3 +319,10 @@ eyeo-beta-118.0.5993.48-android_api.patch
 eyeo-beta-118.0.5993.48-android_settings.patch
 eyeo-beta-118.0.5993.48-extension_api.patch
 Eyeo-Adblock-for-Cromite.patch
+
+#trichrome_patches
+0001-fixup-Disable-fetching-of-all-field-trials.patch
+0002-add-trichrome-browser-apk-targets.patch
+0003-Revert-Keep-disabled-WebViewMediaIntegrityApi.patch
+0004-Revert-Enable-search-engine-settings-desktop-ui.patch
+

--- a/build/patches/0001-fixup-Disable-fetching-of-all-field-trials.patch
+++ b/build/patches/0001-fixup-Disable-fetching-of-all-field-trials.patch
@@ -1,0 +1,59 @@
+From f6722f030c58102eb35af8a3a1cefb8f32226ced Mon Sep 17 00:00:00 2001
+From: althafvly <althafvly@gmail.com>
+Date: Wed, 20 Sep 2023 09:48:52 +0530
+Subject: [PATCH 1/4] fixup Disable fetching of all field trials
+
+---
+ .../services/SafeModeVariationsSeedContentProvider.java   | 8 +-------
+ build/android/gyp/proguard.py                             | 2 ++
+ .../service/variations_field_trial_creator_base.cc        | 2 ++
+ 3 files changed, 5 insertions(+), 7 deletions(-)
+
+diff --git a/android_webview/nonembedded/java/src/org/chromium/android_webview/services/SafeModeVariationsSeedContentProvider.java b/android_webview/nonembedded/java/src/org/chromium/android_webview/services/SafeModeVariationsSeedContentProvider.java
+index 4a5bbb81a6812..c3fd6b3fbd68a 100644
+--- a/android_webview/nonembedded/java/src/org/chromium/android_webview/services/SafeModeVariationsSeedContentProvider.java
++++ b/android_webview/nonembedded/java/src/org/chromium/android_webview/services/SafeModeVariationsSeedContentProvider.java
+@@ -87,13 +87,7 @@ public class SafeModeVariationsSeedContentProvider extends ContentProvider {
+     }
+ 
+     private Boolean awaitSeedResults() {
+-        CountDownLatch countDownLatch = new CountDownLatch(1);
+-        try {
+-            return countDownLatch.await(TIMEOUT_IN_MILLIS, TimeUnit.MILLISECONDS);
+-        } catch (InterruptedException e) {
+-            Log.w(TAG, e.toString());
+-            return false;
+-        }
++        return false;
+     }
+ 
+     @Override
+diff --git a/build/android/gyp/proguard.py b/build/android/gyp/proguard.py
+index 8ee6a884afd9b..ed8139dd90f4e 100755
+--- a/build/android/gyp/proguard.py
++++ b/build/android/gyp/proguard.py
+@@ -54,6 +54,8 @@ _IGNORE_WARNINGS = (
+         r'PaymentRequest[BH]',
+         # com.google.android.gms.cast is stripped down from the build
+         r'class com\.google\.android\.gms\.',
++        # No fetching of trials
++        r'org\.chromium\.android_webview\.services\.AwVariationsSeedFetcher',
+     ]) + ')',
+     # TODO(agrieve): Remove once we update to U SDK.
+     r'OnBackAnimationCallback',
+diff --git a/components/variations/service/variations_field_trial_creator_base.cc b/components/variations/service/variations_field_trial_creator_base.cc
+index bdfbaccfc0e70..2f44107f0110d 100644
+--- a/components/variations/service/variations_field_trial_creator_base.cc
++++ b/components/variations/service/variations_field_trial_creator_base.cc
+@@ -331,6 +331,8 @@ bool VariationsFieldTrialCreatorBase::SetUpFieldTrials(
+                              safe_seed_manager, synthetic_trial_registry);
+   }
+ 
++  platform_field_trials->RegisterFeatureOverrides(feature_list.get());
++
+   base::FeatureList::SetInstance(std::move(feature_list));
+ 
+   // For testing Variations Safe Mode, maybe crash here.
+-- 
+2.34.1
+

--- a/build/patches/0002-add-trichrome-browser-apk-targets.patch
+++ b/build/patches/0002-add-trichrome-browser-apk-targets.patch
@@ -1,0 +1,79 @@
+From 8c3023a731838767417adf0b1ac47dd07329f9b9 Mon Sep 17 00:00:00 2001
+From: Daniel Micay <danielmicay@gmail.com>
+Date: Thu, 27 May 2021 07:30:02 -0400
+Subject: [PATCH 2/4] add trichrome browser apk targets
+
+---
+ chrome/android/BUILD.gn                   | 35 +++++++++++++++++++++++
+ chrome/android/chrome_public_apk_tmpl.gni |  2 ++
+ 2 files changed, 37 insertions(+)
+
+diff --git a/chrome/android/BUILD.gn b/chrome/android/BUILD.gn
+index 47e2216eb964b..0a0be89e09906 100644
+--- a/chrome/android/BUILD.gn
++++ b/chrome/android/BUILD.gn
+@@ -2499,6 +2499,10 @@ if (current_toolchain == default_toolchain) {
+     is_trichrome = true
+     is_bundle_module = true
+   }
++  resource_packaging("trichrome_chrome_apk_pak_assets") {
++    is_monochrome = false
++    is_trichrome = true
++  }
+ 
+   # Exists separately from chrome_public_base_module_java_for_test to allow
+   # downstream to depend on test support packages without needing to depend on
+@@ -2862,6 +2866,37 @@ if (current_toolchain == default_toolchain) {
+       }
+     }
+   }
++ 
++  chrome_public_apk_or_module_tmpl("trichrome_chrome_apk") {
++    apk_name = "TrichromeChrome"
++    is_trichrome = true
++    target_type = "android_apk"
++    static_library_provider = ":trichrome_library_apk"
++    if (android_64bit_target_cpu) {
++      is_64_bit_browser = false
++      include_64_bit_webview = true
++    }
++  }
++  
++  if (android_64bit_target_cpu) {
++    chrome_public_apk_or_module_tmpl("trichrome_chrome_64_32_apk") {
++      apk_name = "TrichromeChrome6432"
++      is_trichrome = true
++      target_type = "android_apk"
++      static_library_provider = ":trichrome_library_64_32_apk"
++      is_64_bit_browser = true
++      include_32_bit_webview = true
++    }
++  
++    chrome_public_apk_or_module_tmpl("trichrome_chrome_64_apk") {
++      apk_name = "TrichromeChrome64"
++      is_trichrome = true
++      target_type = "android_apk"
++      static_library_provider = ":trichrome_library_64_apk"
++      is_64_bit_browser = true
++      include_32_bit_webview = false
++    }
++  }
+ 
+   # As compared to chrome_public_test_apk, this target contains only unit tests
+   # that require on device capabilities. These tests are smaller, more tightly
+diff --git a/chrome/android/chrome_public_apk_tmpl.gni b/chrome/android/chrome_public_apk_tmpl.gni
+index 5da977f1336d8..a040d83e2666b 100644
+--- a/chrome/android/chrome_public_apk_tmpl.gni
++++ b/chrome/android/chrome_public_apk_tmpl.gni
+@@ -475,6 +475,8 @@ template("chrome_common_apk_or_module_tmpl") {
+       asset_deps += [ "//chrome/android:chrome_bundle_module_pak_assets" ]
+     } else if (_is_monochrome) {
+       asset_deps += [ "//chrome/android:monochrome_apk_pak_assets" ]
++    } else if (_is_trichrome) {
++      asset_deps += [ "//chrome/android:trichrome_chrome_apk_pak_assets" ]
+     } else {
+       assert(!_is_trichrome)
+       asset_deps += [ "//chrome/android:chrome_apk_pak_assets" ]
+-- 
+2.34.1
+

--- a/build/patches/0003-Revert-Keep-disabled-WebViewMediaIntegrityApi.patch
+++ b/build/patches/0003-Revert-Keep-disabled-WebViewMediaIntegrityApi.patch
@@ -1,0 +1,25 @@
+From b4810019fc2e9bd05a0af07b348f6b6ea8c149ab Mon Sep 17 00:00:00 2001
+From: althafvly <althafvly@gmail.com>
+Date: Wed, 7 Aug 2024 20:45:15 +0530
+Subject: [PATCH 3/4] Revert "Keep disabled WebViewMediaIntegrityApi"
+
+This reverts commit 88fd9bc5a7d4b16f91c4b20b9fc70290b35782c1.
+---
+ android_webview/common/aw_features.cc | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/android_webview/common/aw_features.cc b/android_webview/common/aw_features.cc
+index 2bcd21fdbc2c0..f3d7c477485ce 100644
+--- a/android_webview/common/aw_features.cc
++++ b/android_webview/common/aw_features.cc
+@@ -259,7 +259,5 @@ BASE_FEATURE(kCreateSpareRendererOnBrowserContextCreation,
+              "CreateSpareRendererOnBrowserContextCreation",
+              base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+-SET_CROMITE_FEATURE_DISABLED(kWebViewMediaIntegrityApi);
+-SET_CROMITE_FEATURE_DISABLED(kWebViewMediaIntegrityApiBlinkExtension);
+ }  // namespace features
+ }  // namespace android_webview
+-- 
+2.34.1
+

--- a/build/patches/0004-Revert-Enable-search-engine-settings-desktop-ui.patch
+++ b/build/patches/0004-Revert-Enable-search-engine-settings-desktop-ui.patch
@@ -1,0 +1,2335 @@
+From fc7cdf50ee5d617df8ecb0b8f3f2e25f4e517677 Mon Sep 17 00:00:00 2001
+From: althafvly <althafvly@gmail.com>
+Date: Wed, 7 Aug 2024 22:58:58 +0530
+Subject: [PATCH 4/4] Revert "Enable search engine settings desktop ui"
+
+This reverts commit 3cb0275a7798b37742a7fffa1fdf3122c7f7f9fa.
+---
+ .../settings/SettingsLauncherImpl.java        |  10 -
+ chrome/app/generated_resources.grd            |   7 +-
+ chrome/app/settings_strings.grdp              |   3 -
+ chrome/app/settings_strings_android.grdp      | 260 ------------------
+ chrome/browser/BUILD.gn                       |   3 -
+ .../chrome_browser_interface_binders.cc       |  12 -
+ chrome/browser/resources/BUILD.gn             |   6 -
+ chrome/browser/resources/settings/BUILD.gn    |   2 +-
+ .../resources/settings/page_visibility.ts     |  30 +-
+ .../search_engine_edit_dialog.html            |   6 -
+ .../search_engine_edit_dialog.ts              |   6 +-
+ .../search_engines_browser_proxy.ts           |   8 +-
+ .../search_engines_page.html                  |  14 +-
+ .../settings/search_page/search_page.html     |   6 +-
+ .../browser/resources/settings/settings.gni   |   2 +-
+ .../browser/resources/settings/settings.html  |   8 +-
+ .../settings/settings_ui/settings_ui.html     |   6 -
+ .../resources/settings_shared/BUILD.gn        |   2 +-
+ chrome/browser/search/background/BUILD.gn     |   4 +-
+ .../browser/search_engines/android/BUILD.gn   |   2 -
+ .../java/res/layout/search_engine_layout.xml  |  25 --
+ .../settings/SearchEngineSettings.java        |  19 --
+ chrome/browser/ui/BUILD.gn                    |  12 -
+ .../edit_search_engine_controller.cc          |   8 +-
+ .../edit_search_engine_controller.h           |   6 +-
+ .../keyword_editor_controller.cc              |  13 +-
+ .../keyword_editor_controller.h               |   6 +-
+ .../template_url_table_model.cc               |   9 +-
+ .../search_engines/template_url_table_model.h |   6 +-
+ .../webui/chrome_web_ui_controller_factory.cc |   6 -
+ chrome/browser/ui/webui/favicon_source.cc     |  18 --
+ chrome/browser/ui/webui/favicon_source.h      |   2 -
+ .../webui/settings/search_engines_handler.cc  |  28 +-
+ .../webui/settings/search_engines_handler.h   |   3 +-
+ .../settings_localized_strings_provider.cc    |   8 -
+ ...ings_localized_strings_provider_android.cc | 198 -------------
+ ...tings_localized_strings_provider_android.h |  19 --
+ .../ui/webui/settings/settings_ui_android.cc  | 134 ---------
+ .../ui/webui/settings/settings_ui_android.h   | 119 --------
+ chrome/chrome_paks.gni                        |  11 -
+ .../browser_ui/settings/SettingsLauncher.java |   2 -
+ .../search_engine_desktop_ui.grdp             |   6 -
+ .../android/template_url_service_android.cc   |   2 +-
+ .../search_engines/search_engines_switches.cc |   1 -
+ .../search_engines/template_url_service.cc    |   8 +-
+ .../search_engines/template_url_service.h     |   6 +-
+ content/browser/webui/web_ui_impl.cc          |  14 +-
+ content/browser/webui/web_ui_impl.h           |   3 -
+ content/public/browser/web_ui.h               |   1 -
+ ui/base/template_expressions.cc               |  21 +-
+ ui/webui/BUILD.gn                             |   8 -
+ ui/webui/resources/BUILD.gn                   |  10 -
+ .../customize_color_scheme_mode/BUILD.gn      |   2 +-
+ .../cr_components/customize_themes/BUILD.gn   |   2 +-
+ .../cr_components/help_bubble/BUILD.gn        |   2 +-
+ .../cr_components/theme_color_picker/BUILD.gn |   2 +-
+ .../cr_elements/cr_dialog/cr_dialog.css       |   2 +-
+ .../resources/cr_elements/cr_shared_vars.css  |   4 -
+ ui/webui/resources/css/BUILD.gn               |   2 +-
+ ui/webui/resources/images/BUILD.gn            |   2 +-
+ ui/webui/resources/include_polymer.gni        |   2 +-
+ ui/webui/resources/js/BUILD.gn                |   2 +-
+ ui/webui/resources/js/load_time_data.ts       |  17 +-
+ 63 files changed, 62 insertions(+), 1106 deletions(-)
+ delete mode 100644 chrome/app/settings_strings_android.grdp
+ delete mode 100644 chrome/browser/search_engines/android/java/res/layout/search_engine_layout.xml
+ delete mode 100644 chrome/browser/ui/webui/settings/settings_localized_strings_provider_android.cc
+ delete mode 100644 chrome/browser/ui/webui/settings/settings_localized_strings_provider_android.h
+ delete mode 100644 chrome/browser/ui/webui/settings/settings_ui_android.cc
+ delete mode 100644 chrome/browser/ui/webui/settings/settings_ui_android.h
+ delete mode 100644 components/browser_ui/strings/bromite_content_settings/search_engine_desktop_ui.grdp
+
+diff --git a/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsLauncherImpl.java b/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsLauncherImpl.java
+index 6130cd0f94c04..88f268d4aa46e 100644
+--- a/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsLauncherImpl.java
++++ b/chrome/android/java/src/org/chromium/chrome/browser/settings/SettingsLauncherImpl.java
+@@ -14,9 +14,6 @@ import androidx.fragment.app.Fragment;
+ 
+ import org.jni_zero.CalledByNative;
+ 
+-import org.chromium.base.ContextUtils;
+-import org.chromium.chrome.browser.customtabs.CustomTabActivity;
+-
+ import org.chromium.base.IntentUtils;
+ import org.chromium.chrome.browser.accessibility.settings.AccessibilitySettings;
+ import org.chromium.chrome.browser.autofill.settings.AutofillPaymentMethodsFragment;
+@@ -39,13 +36,6 @@ public class SettingsLauncherImpl implements SettingsLauncher {
+ 
+     public SettingsLauncherImpl() {}
+ 
+-    @Override
+-    public void launchUrlInCustomTab(Context context, String url) {
+-       CustomTabActivity.showInfoPage(
+-                ContextUtils.activityFromContext(context),
+-                url);
+-    }
+-
+     @Override
+     public void launchSettingsActivity(Context context) {
+         launchSettingsActivity(context, SettingsFragment.MAIN);
+diff --git a/chrome/app/generated_resources.grd b/chrome/app/generated_resources.grd
+index 888a258d3a757..9f4d0e0780aa0 100644
+--- a/chrome/app/generated_resources.grd
++++ b/chrome/app/generated_resources.grd
+@@ -314,11 +314,6 @@ are declared in tools/grit/grit_rule.gni.
+         <part file="shared_settings_strings.grdp"/>
+       </if>
+ 
+-      <if expr="is_android">
+-        <part file="settings_strings_android.grdp" />
+-        <part file="shared_settings_strings.grdp"/>
+-      </if>
+-
+       <!-- Support Tool strings -->
+       <if expr="not is_android">
+         <part file="support_tool_strings.grdp" />
+@@ -505,7 +500,7 @@ are declared in tools/grit/grit_rule.gni.
+         Disable
+       </message>
+       <!-- Search strings are only used in webui, so no mobile. -->
+-      <if expr="not is_android or is_android">
++      <if expr="not is_android">
+         <message name="IDS_SEARCH_CLEARED" desc="Message announced to screenreader users when search is cleared.">
+           Search cleared
+         </message>
+diff --git a/chrome/app/settings_strings.grdp b/chrome/app/settings_strings.grdp
+index 01684554edcf4..3725755b7e8e8 100644
+--- a/chrome/app/settings_strings.grdp
++++ b/chrome/app/settings_strings.grdp
+@@ -2609,9 +2609,6 @@ Please note that it only applies to the states of California (under CCPA and CPR
+   <message name="IDS_SETTINGS_SEARCH_ENGINES_QUERY_URL_EXPLANATION" desc="Label for explaining the format of the URL that should be entered by the user in the add/edit search engine dialog.">
+     URL with <ph name="SPECIAL_SYMBOL">%s</ph> in place of query
+   </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SUGGESTION_URL_EXPLANATION" desc="Label for explaining the format of the URL that should be entered by the user in the add/edit search engine dialog.">
+-    Suggestion URL (with <ph name="SPECIAL_SYMBOL">%s</ph> in place of query)
+-  </message>
+   <message name="IDS_SETTINGS_SEARCH_ENGINES_MAKE_DEFAULT" desc="Text of the button that makes the selected engine the default search engine">
+     Make default
+   </message>
+diff --git a/chrome/app/settings_strings_android.grdp b/chrome/app/settings_strings_android.grdp
+deleted file mode 100644
+index f24b3cf8294f0..0000000000000
+--- a/chrome/app/settings_strings_android.grdp
++++ /dev/null
+@@ -1,260 +0,0 @@
+-<?xml version="1.0" encoding="utf-8"?>
+-<!-- Settings-specific strings (included from generated_resources.grd). -->
+-<grit-part>
+-
+-  <!-- Common -->
+-  <message name="IDS_SETTINGS_ADVANCED" desc="Name of the settings page which displays advanced preferences.">
+-    Advanced
+-  </message>
+-  <message name="IDS_SETTINGS_BASIC" desc="Name of the settings page which displays advanced preferences.">
+-    Basic
+-  </message>
+-  <message name="IDS_SETTINGS_MENU_BUTTON_LABEL" desc="Tooltips for the sidebar menu button.">
+-    Main menu
+-  </message>
+-  <message name="IDS_SETTINGS_MENU_EXTENSIONS_LINK_TOOLTIP" desc="Explanation that the extensions page will open in a new tab">
+-    Opens in a new tab
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_PROMPT" desc="Label for input field to search within settings.">
+-    Search settings
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_NO_RESULTS_HELP" desc="Help text for a search that has no results.">
+-    Go to <ph name="BEGIN_LINK_CHROMIUM">&lt;a target="_blank" href="$1"&gt;</ph>Google Chrome help<ph name="END_LINK_CHROMIUM">&lt;/a&gt;</ph> if you can't find what you're looking for
+-  </message>
+-  <message name="IDS_SETTINGS_SETTINGS" desc="The settings page title.">
+-    Settings
+-  </message>
+-  <message name="IDS_SETTINGS_ALT_PAGE_TITLE" desc="The settings page title for the about page.">
+-    Settings - <ph name="SECTION_TITLE">$1<ex>About Chromium</ex></ph>
+-  </message>
+-  <message name="IDS_SETTINGS_SUBPAGE_BUTTON" desc="Accessibility description for a button navigating the user from a settings page to one of the settings subpages.">
+-    Subpage button
+-  </message>
+-  <message name="IDS_SETTINGS_RESTART" desc="Text for a button that will restart Chrome.">
+-    Relaunch
+-  </message>
+-  <message name="IDS_SETTINGS_CONTROLLED_BY_EXTENSION" desc="Label text of an indicator that a setting's value is being controlled by an extension.">
+-    <ph name="NAME">$1<ex>Adblocker plusplus</ex></ph> is controlling this setting
+-  </message>
+-  <message name="IDS_SETTINGS_CLEAR" desc="Label used on a menu item or button to clear an item.">
+-    Clear
+-  </message>
+-  <message name="IDS_SETTINGS_DELETE" desc="Label used on a menu item or button to delete an item.">
+-    Delete
+-  </message>
+-  <message name="IDS_SETTINGS_EDIT" desc="Label used on a menu item or button, used in different contexts to edit an item.">
+-    Edit
+-  </message>
+-  <message name="IDS_SETTINGS_END_TIME" desc="The label of the end time bubble of settings-scheduler-slider">
+-    End time <ph name="TIME">$1<ex>5:00 AM</ex></ph>
+-  </message>
+-  <message name="IDS_SETTINGS_NOT_VALID" desc="Text indicating that an input is not valid.">
+-    Not valid
+-  </message>
+-  <message name="IDS_SETTINGS_NOT_VALID_WEB_ADDRESS" desc="Text indicating that the Web address entered by the user is invalid." >
+-    Not a valid web address
+-  </message>
+-  <message name="IDS_SETTINGS_NOT_VALID_WEB_ADDRESS_FOR_CONTENT_TYPE" desc="Text indicating that the content setting can't take effect because the setting is limited to secure origins." >
+-    Origin must be secure
+-  </message>
+-  <message name="IDS_SETTINGS_RETRY" desc="The label text of the retry button because there is an error.">
+-    Retry
+-  </message>
+-  <message name="IDS_SETTINGS_SLIDER_MIN_MAX_ARIA_ROLE_DESCRIPTION" desc="A label to be read aloud by screen readers when a user focuses on a slider. A settings slider generally has a minimum value, a maximum value, and a fixed range of values in between. This label gives the user context for what the minimum and maximum values represent for that particular slider.">
+-    Slider: <ph name="MIN_LABEL">$1<ex>Slowest</ex></ph> to <ph name="MAX_LABEL">$2<ex>Fastest</ex></ph>
+-  </message>
+-  <message name="IDS_SETTINGS_START_TIME" desc="The label of the start time bubble of settings-scheduler-slider">
+-    Start time <ph name="TIME">$1<ex>9:06 PM</ex></ph>
+-  </message>
+-
+-<!-- Search Page -->
+-  <message name="IDS_SETTINGS_SEARCH" desc="Name of the settings page which displays search engine preferences.">
+-    Search engine
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_EXPLANATION" desc="Explanation for the search engine dropdown setting.">
+-    Search engine used in the address bar.
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_EXPLANATION_ACCESSIBILITY_LABEL" desc="Accessibility label for a 'learn more' link which links to an article about setting a default search engine.">
+-    Learn more about default search engines
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_MANAGE_SEARCH_ENGINES" desc="Label for the Manage Search Engines button.">
+-    Manage search engines
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_MANAGE_SEARCH_ENGINES_AND_SITE_SEARCH" desc="Label for the Manage Search Engines and Site Search button.">
+-    Manage search engines and site search
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_MANAGE_SEARCH_ENGINES_EXPLANATION" desc="Explanation for the Manage Search Engines button.">
+-    Create shortcuts for searching sites and manage your search engine
+-  </message>
+-
+-<!-- Search Engines Page -->
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES" desc="Name of the settings page which manages search engines.">
+-    Search Engines
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_PAGE_EXPLANATION" desc="Explanation of the Manage Search Engines page">
+-    You can use shortcuts in the address bar to quickly search a specific site or to use a different search engine
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SEARCH" desc="Label for a text input placeholder allowing the user to search/filter the displayed search engines">
+-    Search
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_ADD_SEARCH_ENGINE" desc="Title for a dialog that allows adding a new search engine.">
+-    Add search engine
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_EDIT_SEARCH_ENGINE" desc="Title for a dialog that allows editing an existing search engine.">
+-    Edit search engine
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_DELETE_CONFIRMATION_TITLE" desc="Title for a dialog that confirms that a user wants to delete an existing search engine.">
+-    Delete search engine
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_DELETE_CONFIRMATION_DESCRIPTION" desc="Description text for a dialog that confirms that a user wants to delete an existing search engine.">
+-    Are you sure you want to delete this search engine?
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SEARCH_ENGINES" desc="Label for 'Search Engines' section">
+-    Search engines
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SEARCH_ENGINES_EXPLANATION" desc="Explanation for 'Search Engines' section">
+-    To use a search engine other than the default, type its shortcut in the address bar followed by your preferred keyboard shortcut. You can also change your default search engine here.
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SITE_SEARCH" desc="Label for 'Site Search' section">
+-    Site search
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SITE_SEARCH_EXPLANATION" desc="Explanation for 'Site Search' section. Used interchangeably with IDS_SETTINGS_SEARCH_ENGINES_SITE_SEARCH_EXPLANATION_STARTER_PACK">
+-    To search a specific site or part of Chrome, type its shortcut in the address bar, followed by your preferred keyboard shortcut.
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SITE_SEARCH_EXPLANATION_STARTER_PACK" desc="Explanation for 'Site Search' section">
+-    To search a specific site or part of Chrome, type its shortcut in the address bar, followed by your preferred keyboard shortcut. For example, to search only Bookmarks, type "@bookmarks", then press Tab or Space.
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_NO_SITES_ADDED" desc="Text shown when the 'Site Search' section is empty">
+-    No sites added
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_INACTIVE_SHORTCUTS" desc="Label for 'Inactive shortcuts' section">
+-    Inactive shortcuts
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_NO_OTHER_ENGINES" desc="Label shown when the 'other' Search engines section is empty">
+-    Other saved search engines will appear here
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_EXTENSION_ENGINES" desc="Label for a section that displays search engines added by extensions">
+-    Extensions
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_EXTENSION_ENGINES_EXPLANATION" desc="Explanation for a section that displays search engines added by extensions">
+-    Some extensions can add search engines to Chrome
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SEARCH_ENGINE" desc="Label for a table column that holds the name of a search engine">
+-    Search engine
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SITE_OR_PAGE" desc="Label for a table column that holds the name of a site or page in the 'Site search' section">
+-    Site or page
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SHORTCUT" desc="Label for Shortcut column header for a search engine or site search entry">
+-    Shortcut
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_NAME" desc="Label for a table column that holds the name of a search engine or site search provider">
+-    Name
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_QUERY_URL" desc="Label for Query URL column header for a search engine">
+-    Query URL
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_QUERY_URL_EXPLANATION" desc="Label for explaining the format of the URL that should be entered by the user in the add/edit search engine dialog.">
+-    URL with <ph name="SPECIAL_SYMBOL">%s</ph> in place of query
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_SUGGESTION_URL_EXPLANATION" desc="Label for explaining the format of the URL that should be entered by the user in the add/edit search engine dialog.">
+-    Suggestion URL (with <ph name="SPECIAL_SYMBOL">%s</ph> in place of query)
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_MAKE_DEFAULT" desc="Text of the button that makes the selected engine the default search engine">
+-    Make default
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_ACTIVATE" desc="Text of the button that activates a search engine">
+-    Activate
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_DEACTIVATE" desc="Text of the button that deactivates a search engine">
+-    Deactivate
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_MANAGE_EXTENSION" desc="Text displayed for a button that allows the user to manage a Chrome extension">
+-    Manage
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_KEYBOARD_SHORTCUTS_TITLE" desc="Label for scoped search mode trigger options section">
+-    Keyboard shortcut
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_KEYBOARD_SHORTCUTS_DESCRIPTION" desc="Text explaining how to use keyword mode">
+-    In the address bar, use this keyboard shortcut with shortcuts for search engines and site search
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_KEYBOARD_SHORTCUTS_DESCRIPTION_STARTER_PACK" desc="Text explaining how to use keyboard mode, if scoped search starter pack is enabled">
+-    In the address bar, enter the shortcut for the site you want to search, such as "@bookmarks". Then, press your preferred keyboard shortcut, and enter your search term.
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_KEYBOARD_SHORTCUTS_SPACE_OR_TAB" desc="Label for setting that toggles whether scoped search mode can be triggered by space">
+-    Space or Tab
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_KEYBOARD_SHORTCUTS_TAB" desc="Label for setting that toggles whether scoped search mode can be triggered by space" meaning="Describes the tab key or button on the user’s keyboard.">
+-    Tab
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_ADDITIONAL_SITES" desc="Label for button that expands the Site Search list of search engines to show all entries">
+-    Additional sites
+-  </message>
+-  <message name="IDS_SETTINGS_SEARCH_ENGINES_ADDITIONAL_INACTIVE_SITES" desc="Label for button that expands the Inactive Sites list of search engines to show all entries">
+-    Additional inactive sites
+-  </message>
+-
+-<!-- Generic terms -->
+-  <message name="IDS_ADD2" desc="Used for Add on buttons">
+-    Add
+-  </message>
+-  <message name="IDS_CANCEL2" desc="Used for Cancel on buttons">
+-    Cancel
+-  </message>
+-  <message name="IDS_CLOSE2" desc="A generic term for Close on buttons and menus.">
+-    Close
+-  </message>
+-  <message name="IDS_DONE2" desc="A generic term for Done on buttons and menus.">
+-    Done
+-  </message>
+-  <message name="IDS_LEARN_MORE2" desc="Learn more text">
+-    Learn more
+-  </message>
+-  <message name="IDS_MENU2" desc="The accessible name for the Menu. This is used as the aria-roledescription for context menus." formatter_data="android_java">
+-    Menu
+-  </message>
+-
+-  <message name="IDS_NO_THANKS2" desc="Used to dismiss various prompts.">
+-    No thanks
+-  </message>
+-  <message name="IDS_OK2" desc="Used for OK on buttons">
+-    OK
+-  </message>
+-  <message name="IDS_REMOVE2" desc="Used for Remove on buttons">
+-    Remove
+-  </message>
+-  <message name="IDS_SAVE2" desc="Used on a button to save information you are editing.">
+-    Save
+-  </message>
+-
+-<!-- Accessibility labels for generic items -->
+-  <message name="IDS_ACCNAME_BACK2" desc="The accessible name for the back button.">
+-    Back
+-  </message>
+-
+-  <message name="IDS_SETTINGS_MANAGE" desc="Text displayed on a button, which when clicked opens the Extensions subpage for managing an extension">
+-    Manage
+-  </message>
+-  <message name="IDS_SETTINGS_FONTS" desc="Title for the customize fonts page in settings.">
+-    Fonts
+-  </message>
+-
+-  <!-- Shared across multiple pages -->
+-  <message name="IDS_SETTINGS_CONTINUE" desc="Label for 'Continue' buttons.">
+-    Continue
+-  </message>
+-  <message name="IDS_SETTINGS_MORE_ACTIONS" desc="Tooltip text (shows on hover or for screenreaders) for a button that shows a menu with more actions when clicked or tapped">
+-    More actions
+-  </message>
+-  <message name="IDS_SETTINGS_SEND_FEEDBACK_ROLE_DESCRIPTION" desc="Accessibility role description for the send feedback button at the top right of a settings section. Spoken by screen readers when focusing the button but not visually rendered.">
+-    Send feedback button
+-  </message>
+-  <message name="IDS_SETTINGS_CUSTOM" desc="Label for a custom option in a dropdown menu.">
+-    Custom
+-  </message>
+-  <message name="IDS_SETTINGS_OPENS_IN_NEW_TAB" desc="ARIA (accessibility) label describing a link which opens in a new tab.">
+-    Opens in new tab
+-  </message>
+-
+-
+-</grit-part>
+diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
+index b21d6533d52fd..1f96b9e9438d3 100644
+--- a/chrome/browser/BUILD.gn
++++ b/chrome/browser/BUILD.gn
+@@ -3803,9 +3803,6 @@ static_library("browser") {
+         "//components/user_scripts/android",
+       ]
+     }
+-    deps += [
+-      "//ui/webui/resources/cr_components/help_bubble:mojo_bindings",
+-    ]
+   } else {
+     #!is_android
+     sources += [
+diff --git a/chrome/browser/chrome_browser_interface_binders.cc b/chrome/browser/chrome_browser_interface_binders.cc
+index 04d40b5232ab0..8ee7c888ea28b 100644
+--- a/chrome/browser/chrome_browser_interface_binders.cc
++++ b/chrome/browser/chrome_browser_interface_binders.cc
+@@ -150,9 +150,6 @@
+ #endif
+ 
+ #if BUILDFLAG(IS_ANDROID)
+-#include "ui/webui/resources/cr_components/help_bubble/help_bubble.mojom.h"
+-#include "ui/webui/resources/cr_components/customize_color_scheme_mode/customize_color_scheme_mode.mojom.h"
+-#include "chrome/browser/ui/webui/settings/settings_ui_android.h"
+ #include "chrome/browser/android/dom_distiller/distiller_ui_handle_android.h"
+ #include "chrome/browser/offline_pages/android/offline_page_auto_fetcher.h"
+ #include "chrome/browser/ui/webui/feed_internals/feed_internals.mojom.h"
+@@ -1180,15 +1177,6 @@ void PopulateChromeWebUIFrameBinders(
+       app_management::mojom::PageHandlerFactory, WebAppSettingsUI>(map);
+ #endif
+ 
+-#if BUILDFLAG(IS_ANDROID)
+-  RegisterWebUIControllerInterfaceBinder<
+-      help_bubble::mojom::HelpBubbleHandlerFactory, settings::SettingsUI>(map);
+-
+-  RegisterWebUIControllerInterfaceBinder<
+-      customize_color_scheme_mode::mojom::
+-          CustomizeColorSchemeModeHandlerFactory, settings::SettingsUI>(map);
+-#endif
+-
+ #if !BUILDFLAG(IS_ANDROID)
+   if (search_engines::IsChoiceScreenFlagEnabled(
+           search_engines::ChoicePromo::kAny)) {
+diff --git a/chrome/browser/resources/BUILD.gn b/chrome/browser/resources/BUILD.gn
+index 602d6d40be306..efd8134849f32 100644
+--- a/chrome/browser/resources/BUILD.gn
++++ b/chrome/browser/resources/BUILD.gn
+@@ -24,12 +24,6 @@ group("resources") {
+     "segmentation_internals:resources",
+   ]
+ 
+-  if (is_android) {
+-    public_deps += [
+-      "settings:resources",
+-      "settings_shared:resources",
+-    ]
+-  }
+   if (!is_android) {
+     public_deps += [
+       ":app_icon_resources",
+diff --git a/chrome/browser/resources/settings/BUILD.gn b/chrome/browser/resources/settings/BUILD.gn
+index 707404c5007b8..c72579c2dd6ac 100644
+--- a/chrome/browser/resources/settings/BUILD.gn
++++ b/chrome/browser/resources/settings/BUILD.gn
+@@ -8,7 +8,7 @@ import("//crypto/features.gni")
+ import("//ui/webui/resources/tools/build_webui.gni")
+ import("./settings.gni")
+ 
+-#assert(!is_android, "Android does not use these settings")
++assert(!is_android, "Android does not use these settings")
+ 
+ build_webui("build") {
+   grd_prefix = "settings"
+diff --git a/chrome/browser/resources/settings/page_visibility.ts b/chrome/browser/resources/settings/page_visibility.ts
+index 0de08a7c36758..38f43d16b5675 100644
+--- a/chrome/browser/resources/settings/page_visibility.ts
++++ b/chrome/browser/resources/settings/page_visibility.ts
+@@ -43,36 +43,8 @@ export interface PrivacyPageVisibility {
+   searchPrediction: boolean;
+ }
+ 
+-const isAndroid = (loadTimeData.getString('chromeAndroid') !== "");
+-if (isAndroid) {
+-  // @ts-expect-error
+-  chrome.autofillPrivate = {};
+-
+-  // @ts-expect-error
+-  chrome.languageSettingsPrivate = {};
+-
+-  // @ts-expect-error
+-  chrome.metricsPrivate = {
+-    recordSparseValueWithPersistentHash: function() {}
+-  };
+-
+-  // @ts-expect-error
+-  chrome.settingsPrivate_ = {
+-    onPrefsChanged: {
+-      addListener: function() {}
+-    },
+-    getAllPrefs: function() {
+-      var obj = {};
+-      (obj as any).then = function() {};
+-      return obj;
+-    }
+-  }
+-  // @ts-expect-error
+-  chrome.settingsPrivate = chrome.settingsPrivate_;
+-}
+-
+ function createPageVisibility(): PageVisibility|undefined {
+-  if (!loadTimeData.getBoolean('isGuest') || isAndroid) {
++  if (!loadTimeData.getBoolean('isGuest')) {
+     return undefined;
+   }
+ 
+diff --git a/chrome/browser/resources/settings/search_engines_page/search_engine_edit_dialog.html b/chrome/browser/resources/settings/search_engines_page/search_engine_edit_dialog.html
+index acff6efe69ca7..d55ab335b90d3 100644
+--- a/chrome/browser/resources/settings/search_engines_page/search_engine_edit_dialog.html
++++ b/chrome/browser/resources/settings/search_engines_page/search_engine_edit_dialog.html
+@@ -22,12 +22,6 @@
+             error-message="$i18n{notValid}"
+             value="{{queryUrl_}}" on-focus="validate_" on-input="validate_">
+         </cr-input>
+-        <cr-input id="suggestionUrl"
+-            label="$i18n{searchEnginesSuggestionURLExplanation}"
+-            error-message="$i18n{notValid}"
+-            value="{{suggestionUrl_}}" on-focus="validate_" on-input="validate_"
+-            disabled$="[[model.urlLocked]]">
+-        </cr-input>
+       </div>
+       <div slot="button-container">
+         <cr-button class="cancel-button" on-click="cancel_" id="cancel"
+diff --git a/chrome/browser/resources/settings/search_engines_page/search_engine_edit_dialog.ts b/chrome/browser/resources/settings/search_engines_page/search_engine_edit_dialog.ts
+index a5fb6370ac8d1..7ffe05a27a195 100644
+--- a/chrome/browser/resources/settings/search_engines_page/search_engine_edit_dialog.ts
++++ b/chrome/browser/resources/settings/search_engines_page/search_engine_edit_dialog.ts
+@@ -64,7 +64,6 @@ export class SettingsSearchEngineEditDialogElement extends
+       searchEngine_: String,
+       keyword_: String,
+       queryUrl_: String,
+-      suggestionUrl_: String,
+       dialogTitle_: String,
+       actionButtonText_: String,
+       cancelButtonHidden_: Boolean,
+@@ -80,7 +79,6 @@ export class SettingsSearchEngineEditDialogElement extends
+   private searchEngine_: string;
+   private keyword_: string;
+   private queryUrl_: string;
+-  private suggestionUrl_: string;
+   private dialogTitle_: string;
+   private actionButtonText_: string;
+   private cancelButtonHidden_: boolean;
+@@ -110,7 +108,7 @@ export class SettingsSearchEngineEditDialogElement extends
+       this.searchEngine_ = this.model.name;
+       this.keyword_ = this.model.keyword;
+       this.queryUrl_ = this.model.url;
+-      this.suggestionUrl_ = this.model.suggestionurl;
++      this.readonly_ = this.model.isManaged;
+     } else {
+       this.dialogTitle_ = loadTimeData.getString('searchEnginesAddSiteSearch');
+       this.actionButtonText_ = loadTimeData.getString('add');
+@@ -156,7 +154,7 @@ export class SettingsSearchEngineEditDialogElement extends
+ 
+   private onActionButtonClick_() {
+     this.browserProxy_.searchEngineEditCompleted(
+-        this.searchEngine_, this.keyword_, this.queryUrl_, this.suggestionUrl_);
++        this.searchEngine_, this.keyword_, this.queryUrl_);
+     this.$.dialog.close();
+   }
+ 
+diff --git a/chrome/browser/resources/settings/search_engines_page/search_engines_browser_proxy.ts b/chrome/browser/resources/settings/search_engines_page/search_engines_browser_proxy.ts
+index 70e8de898681c..ca37c7d2366cc 100644
+--- a/chrome/browser/resources/settings/search_engines_page/search_engines_browser_proxy.ts
++++ b/chrome/browser/resources/settings/search_engines_page/search_engines_browser_proxy.ts
+@@ -35,7 +35,6 @@ export interface SearchEngine {
+   name: string;
+   shouldConfirmDeletion: boolean;
+   url: string;
+-  suggestionurl: string;
+   urlLocked: boolean;
+ }
+ 
+@@ -100,7 +99,7 @@ export interface SearchEnginesBrowserProxy {
+   searchEngineEditCancelled(): void;
+ 
+   searchEngineEditCompleted(
+-      searchEngine: string, keyword: string, queryUrl: string, suggestionUrl: string): void;
++      searchEngine: string, keyword: string, queryUrl: string): void;
+ 
+   getSearchEnginesList(): Promise<SearchEnginesInfo>;
+ 
+@@ -142,12 +141,11 @@ export class SearchEnginesBrowserProxyImpl implements
+   }
+ 
+   searchEngineEditCompleted(
+-      searchEngine: string, keyword: string, queryUrl: string, suggestionUrl: string) {
++      searchEngine: string, keyword: string, queryUrl: string) {
+     chrome.send('searchEngineEditCompleted', [
+       searchEngine,
+       keyword,
+       queryUrl,
+-      suggestionUrl
+     ]);
+   }
+ 
+@@ -160,7 +158,7 @@ export class SearchEnginesBrowserProxyImpl implements
+   }
+ 
+   recordSearchEnginesPageHistogram(interaction: SearchEnginesInteractions) {
+-    chrome.metricsPrivate?.recordEnumerationValue(
++    chrome.metricsPrivate.recordEnumerationValue(
+         'Settings.SearchEngines.Interactions', interaction,
+         SearchEnginesInteractions.COUNT);
+   }
+diff --git a/chrome/browser/resources/settings/search_engines_page/search_engines_page.html b/chrome/browser/resources/settings/search_engines_page/search_engines_page.html
+index c8bc34c6fc251..fabc3e47df84c 100644
+--- a/chrome/browser/resources/settings/search_engines_page/search_engines_page.html
++++ b/chrome/browser/resources/settings/search_engines_page/search_engines_page.html
+@@ -3,7 +3,6 @@
+         border-top: var(--cr-separator-line);
+       }
+     </style>
+-<if expr="not is_android">
+     <div class="cr-row first">
+       <div class="secondary">$i18n{searchEnginesPageExplanation}</div>
+     </div>
+@@ -35,14 +34,10 @@
+         </controlled-radio-button>
+       </settings-radio-group>
+     </div>
+-</if>
++
+     <div class="cr-row first">
+       <div class="flex cr-padded-text">
+-        <h2
+-<if expr="is_android">
+-         style="padding-top:0px"
+-</if>
+-        >$i18n{searchEnginesSearchEngines}</h2>
++        <h2>$i18n{searchEnginesSearchEngines}</h2>
+         <div class="secondary">
+           $i18n{searchEnginesSearchEnginesExplanation}
+         </div>
+@@ -106,10 +101,7 @@
+         hidden="[[!matchingOtherEngines_.length]]"
+         engines="[[matchingOtherEngines_]]"
+         scroll-target="[[subpageScrollTarget]]"
+-<if expr="not is_android">
+-        show-query-url
+-</if>
+-        collapse-list
++        show-query-url collapse-list
+         expand-list-text="$i18n{searchEnginesAdditionalInactiveSites}">
+     </settings-search-engines-list>
+ 
+diff --git a/chrome/browser/resources/settings/search_page/search_page.html b/chrome/browser/resources/settings/search_page/search_page.html
+index 0cf8e5cf822bb..e22f37eac55f4 100644
+--- a/chrome/browser/resources/settings/search_page/search_page.html
++++ b/chrome/browser/resources/settings/search_page/search_page.html
+@@ -133,11 +133,7 @@
+         associated-control="[[$$('#enginesSubpageTrigger')]]"
+         page-title="$i18n{searchEnginesManageSiteSearch}"
+         search-label="$i18n{searchEnginesSearch}"
+-        search-term="{{searchEnginesFilter_}}"
+-<if expr="is_android">
+-        hide-close-button="true"
+-</if>
+-        style="max-width: calc(100vw)">
++        search-term="{{searchEnginesFilter_}}">
+       <settings-search-engines-page prefs="{{prefs}}"
+           filter="[[searchEnginesFilter_]]">
+     </settings-subpage>
+diff --git a/chrome/browser/resources/settings/settings.gni b/chrome/browser/resources/settings/settings.gni
+index 755474b2fe91b..4952b09b0e7a6 100644
+--- a/chrome/browser/resources/settings/settings.gni
++++ b/chrome/browser/resources/settings/settings.gni
+@@ -4,7 +4,7 @@
+ 
+ import("//third_party/closure_compiler/compile_js.gni")
+ 
+-#assert(!is_android, "Android does not use these settings")
++assert(!is_android, "Android does not use these settings")
+ 
+ settings_closure_flags =
+     default_closure_args + [
+diff --git a/chrome/browser/resources/settings/settings.html b/chrome/browser/resources/settings/settings.html
+index 83bf9fb7439ff..6af2c41d1842f 100644
+--- a/chrome/browser/resources/settings/settings.html
++++ b/chrome/browser/resources/settings/settings.html
+@@ -1,14 +1,8 @@
+ <!doctype html>
+-<html dir="$i18n{textdirection}" lang="$i18n{language}" class="loading"
+-<if expr="is_android">
+-  $i18n{chromeAndroid}
+-</if>>
++<html dir="$i18n{textdirection}" lang="$i18n{language}" class="loading">
+ <head>
+   <meta charset="utf-8">
+   <meta name="color-scheme" content="light dark">
+-<if expr="is_android">
+-  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+-</if>
+   <title>$i18n{settings}</title>
+   <base href="chrome://settings">
+   <link rel="stylesheet" href="chrome://resources/css/md_colors.css">
+diff --git a/chrome/browser/resources/settings/settings_ui/settings_ui.html b/chrome/browser/resources/settings/settings_ui/settings_ui.html
+index 1f34d34bf5059..9ce552745925c 100644
+--- a/chrome/browser/resources/settings/settings_ui/settings_ui.html
++++ b/chrome/browser/resources/settings/settings_ui/settings_ui.html
+@@ -44,9 +44,6 @@
+         display: flex;
+         flex: 1;
+         overflow: overlay;
+-<if expr="is_android">
+-        overflow-x: hidden;
+-</if>
+         position: relative;
+       }
+ 
+@@ -87,9 +84,6 @@
+     </style>
+     <settings-prefs id="prefs" prefs="{{prefs}}"></settings-prefs>
+     <cr-toolbar id="toolbar"
+-<if expr="is_android">
+-        style="display:none"
+-</if>
+         page-name="$i18n{settings}"
+         clear-label="$i18n{clearSearch}"
+         autofocus
+diff --git a/chrome/browser/resources/settings_shared/BUILD.gn b/chrome/browser/resources/settings_shared/BUILD.gn
+index f2f285e1e0aed..ae3769c77e1b1 100644
+--- a/chrome/browser/resources/settings_shared/BUILD.gn
++++ b/chrome/browser/resources/settings_shared/BUILD.gn
+@@ -4,7 +4,7 @@
+ 
+ import("//ui/webui/resources/tools/build_webui.gni")
+ 
+-#assert(!is_android)
++assert(!is_android)
+ 
+ build_webui("build") {
+   grd_prefix = "settings_shared"
+diff --git a/chrome/browser/search/background/BUILD.gn b/chrome/browser/search/background/BUILD.gn
+index 7ee4e8be65fbe..3d295f6d89428 100644
+--- a/chrome/browser/search/background/BUILD.gn
++++ b/chrome/browser/search/background/BUILD.gn
+@@ -2,11 +2,10 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-# assert(is_win || is_mac || is_linux || is_chromeos)
++assert(is_win || is_mac || is_linux || is_chromeos)
+ 
+ import("//third_party/protobuf/proto_library.gni")
+ 
+-if (!is_android) {
+ source_set("background") {
+   public = [
+     "ntp_background_data.h",
+@@ -62,7 +61,6 @@ source_set("background") {
+     "//ui/gfx/codec",
+   ]
+ }
+-}
+ 
+ proto_library("ntp_background_proto") {
+   sources = [ "ntp_background.proto" ]
+diff --git a/chrome/browser/search_engines/android/BUILD.gn b/chrome/browser/search_engines/android/BUILD.gn
+index 640009491aa35..832e9b9dff02d 100644
+--- a/chrome/browser/search_engines/android/BUILD.gn
++++ b/chrome/browser/search_engines/android/BUILD.gn
+@@ -78,7 +78,6 @@ android_resources("java_resources") {
+     "java/res/layout/default_search_engine_dialog_view.xml",
+     "java/res/layout/search_engine.xml",
+     "java/res/layout/search_engine_choice_header.xml",
+-    "java/res/layout/search_engine_layout.xml",
+     "java/res/layout/search_engine_choice_item.xml",
+     "java/res/layout/search_engine_choice_view.xml",
+     "java/res/layout/search_engine_recent_title.xml",
+@@ -87,7 +86,6 @@ android_resources("java_resources") {
+     "java/res/values/ids.xml",
+   ]
+   deps = [
+-    "//chrome/browser/search/background:ntp_background_proto",
+     "//chrome/browser/ui/android/strings:ui_strings_grd",
+     "//components/browser_ui/styles/android:java_resources",
+     "//components/browser_ui/widget/android:java_resources",
+diff --git a/chrome/browser/search_engines/android/java/res/layout/search_engine_layout.xml b/chrome/browser/search_engines/android/java/res/layout/search_engine_layout.xml
+deleted file mode 100644
+index 5fbab7444ded7..0000000000000
+--- a/chrome/browser/search_engines/android/java/res/layout/search_engine_layout.xml
++++ /dev/null
+@@ -1,25 +0,0 @@
+-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+-              xmlns:app="http://schemas.android.com/apk/res-auto"
+-              android:layout_width="match_parent"
+-              android:layout_height="wrap_content"
+-              android:orientation="vertical">
+-
+-    <org.chromium.ui.widget.ButtonCompat
+-        android:id="@+id/open_desktop_ui"
+-        style="@style/TextButton"
+-        android:layout_width="match_parent"
+-        android:layout_height="wrap_content"
+-        android:paddingBottom="16dp"
+-        android:paddingTop="16dp"
+-        android:text="@string/search_engine_open_desktop_ui"
+-        app:verticalInset="0dp" />
+-
+-    <ListView
+-        android:id="@android:id/list"
+-        android:layout_width="match_parent"
+-        android:layout_height="wrap_content"
+-        android:layout_alignParentLeft="true"
+-        android:layout_alignParentTop="true" >
+-    </ListView>
+-
+-</LinearLayout>
+diff --git a/chrome/browser/search_engines/android/java/src/org/chromium/chrome/browser/search_engines/settings/SearchEngineSettings.java b/chrome/browser/search_engines/android/java/src/org/chromium/chrome/browser/search_engines/settings/SearchEngineSettings.java
+index 7dcd55ef13a9b..1f8e46710fe1a 100644
+--- a/chrome/browser/search_engines/android/java/src/org/chromium/chrome/browser/search_engines/settings/SearchEngineSettings.java
++++ b/chrome/browser/search_engines/android/java/src/org/chromium/chrome/browser/search_engines/settings/SearchEngineSettings.java
+@@ -8,10 +8,6 @@ import android.os.Bundle;
+ import android.view.View;
+ import android.widget.ListView;
+ 
+-import android.view.LayoutInflater;
+-import android.view.ViewGroup;
+-import android.widget.TextView;
+-
+ import androidx.fragment.app.ListFragment;
+ 
+ import org.chromium.chrome.browser.profiles.Profile;
+@@ -31,7 +27,6 @@ import org.chromium.components.search_engines.TemplateUrlService;
+ public class SearchEngineSettings extends ListFragment implements ProfileDependentSetting {
+     private SearchEngineAdapter mSearchEngineAdapter;
+     private Profile mProfile;
+-    private SettingsLauncher mSettingsLauncher;
+ 
+     String getValueForTesting() {
+         return mSearchEngineAdapter.getValueForTesting();
+@@ -53,19 +48,6 @@ public class SearchEngineSettings extends ListFragment implements ProfileDepende
+         setListAdapter(mSearchEngineAdapter);
+     }
+ 
+-    @Override
+-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+-                             Bundle savedInstanceState) {
+-        View v = inflater.inflate(R.layout.search_engine_layout, null);
+-
+-        TextView selectButton = (TextView) v.findViewById(R.id.open_desktop_ui);
+-        selectButton.setOnClickListener(view -> {
+-            mSettingsLauncher.launchUrlInCustomTab(getContext(),
+-                "chrome://settings/searchEngines");
+-        });
+-        return v;
+-    }
+-
+     @Override
+     public void onViewCreated(View view, Bundle savedInstanceState) {
+         super.onViewCreated(view, savedInstanceState);
+@@ -110,7 +92,6 @@ public class SearchEngineSettings extends ListFragment implements ProfileDepende
+      * @param settingsLauncher The SettingsLauncher that is injected.
+      */
+     public void setSettingsLauncher(SettingsLauncher settingsLauncher) {
+-        mSettingsLauncher = settingsLauncher;
+         createAdapterIfNecessary();
+         mSearchEngineAdapter.setSettingsLauncher(settingsLauncher);
+     }
+diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
+index ce3b2d11d820b..c82e3dd8ee740 100644
+--- a/chrome/browser/ui/BUILD.gn
++++ b/chrome/browser/ui/BUILD.gn
+@@ -1108,18 +1108,6 @@ static_library("ui") {
+ 
+     # TODO(b/335257259): Resolve circular deps.
+     allow_circular_includes_from += [ "//chrome/browser/facilitated_payments" ]
+-    sources += [
+-      "webui/settings/settings_ui_android.cc",
+-      "webui/settings/settings_ui_android.h",
+-      "webui/settings/search_engines_handler.cc",
+-      "webui/settings/search_engines_handler.h",
+-      "webui/settings/settings_page_ui_handler.cc",
+-      "webui/settings/settings_page_ui_handler.h",
+-      "webui/settings/settings_localized_strings_provider_android.cc",
+-      "webui/settings/settings_localized_strings_provider_android.h",
+-      "webui/favicon_source.cc",
+-      "webui/favicon_source.h",
+-    ]
+   } else {
+     # !is_android
+     sources += [
+diff --git a/chrome/browser/ui/search_engines/edit_search_engine_controller.cc b/chrome/browser/ui/search_engines/edit_search_engine_controller.cc
+index c5a92d16e9983..af4b8e2c1d260 100644
+--- a/chrome/browser/ui/search_engines/edit_search_engine_controller.cc
++++ b/chrome/browser/ui/search_engines/edit_search_engine_controller.cc
+@@ -89,11 +89,9 @@ bool EditSearchEngineController::IsKeywordValid(
+ void EditSearchEngineController::AcceptAddOrEdit(
+     const std::u16string& title_input,
+     const std::u16string& keyword_input,
+-    const std::string& url_input,
+-    const std::string& url_suggestion_input) {
++    const std::string& url_input) {
+   DCHECK(!keyword_input.empty());
+   std::string url_string = GetFixedUpURL(url_input);
+-  std::string url_suggestion = GetFixedUpURL(url_suggestion_input);
+   DCHECK(!url_string.empty());
+ 
+   TemplateURLService* template_url_service =
+@@ -117,12 +115,12 @@ void EditSearchEngineController::AcceptAddOrEdit(
+     DCHECK(template_url_);
+     template_url_service->AddWithOverrides(
+         base::WrapUnique(template_url_.get()), title_input, keyword_input,
+-        url_string, url_suggestion);
++        url_string);
+     base::RecordAction(UserMetricsAction("KeywordEditor_AddKeywordJS"));
+   } else {
+     // Adding or modifying an entry via the Delegate.
+     edit_keyword_delegate_->OnEditedKeyword(template_url_, title_input,
+-                                            keyword_input, url_string, url_suggestion);
++                                            keyword_input, url_string);
+   }
+ }
+ 
+diff --git a/chrome/browser/ui/search_engines/edit_search_engine_controller.h b/chrome/browser/ui/search_engines/edit_search_engine_controller.h
+index 6327f141f68b0..ec03d9e49193b 100644
+--- a/chrome/browser/ui/search_engines/edit_search_engine_controller.h
++++ b/chrome/browser/ui/search_engines/edit_search_engine_controller.h
+@@ -23,8 +23,7 @@ class EditSearchEngineControllerDelegate {
+   virtual void OnEditedKeyword(TemplateURL* template_url,
+                                const std::u16string& title,
+                                const std::u16string& keyword,
+-                               const std::string& url,
+-                               const std::string& suggestion_url) = 0;
++                               const std::string& url) = 0;
+ 
+  protected:
+   virtual ~EditSearchEngineControllerDelegate() {}
+@@ -63,8 +62,7 @@ class EditSearchEngineController {
+   // Completes the add or edit of a search engine.
+   void AcceptAddOrEdit(const std::u16string& title_input,
+                        const std::u16string& keyword_input,
+-                       const std::string& url_input,
+-                       const std::string& url_suggestion);
++                       const std::string& url_input);
+ 
+   // Deletes an unused TemplateURL, if its add was cancelled and it's not
+   // already owned by the TemplateURLService.
+diff --git a/chrome/browser/ui/search_engines/keyword_editor_controller.cc b/chrome/browser/ui/search_engines/keyword_editor_controller.cc
+index 38403a6fc9073..fa1dce9e3fa5f 100644
+--- a/chrome/browser/ui/search_engines/keyword_editor_controller.cc
++++ b/chrome/browser/ui/search_engines/keyword_editor_controller.cc
+@@ -26,14 +26,13 @@ KeywordEditorController::~KeywordEditorController() {
+ 
+ int KeywordEditorController::AddTemplateURL(const std::u16string& title,
+                                             const std::u16string& keyword,
+-                                            const std::string& url,
+-                                            const std::string& suggestion_url) {
++                                            const std::string& url) {
+   DCHECK(!url.empty());
+ 
+   base::RecordAction(UserMetricsAction("KeywordEditor_AddKeyword"));
+ 
+   const int new_index = table_model_->last_other_engine_index();
+-  table_model_->Add(new_index, title, keyword, url, suggestion_url);
++  table_model_->Add(new_index, title, keyword, url);
+ 
+   return new_index;
+ }
+@@ -41,8 +40,7 @@ int KeywordEditorController::AddTemplateURL(const std::u16string& title,
+ void KeywordEditorController::ModifyTemplateURL(TemplateURL* template_url,
+                                                 const std::u16string& title,
+                                                 const std::u16string& keyword,
+-                                                const std::string& url,
+-                                                const std::string& suggestion_url) {
++                                                const std::string& url) {
+   DCHECK(!url.empty());
+   const std::optional<size_t> index =
+       table_model_->IndexOfTemplateURL(template_url);
+@@ -54,11 +52,10 @@ void KeywordEditorController::ModifyTemplateURL(TemplateURL* template_url,
+ 
+   // Don't do anything if the entry didn't change.
+   if ((template_url->short_name() == title) &&
+-      (template_url->keyword() == keyword) && (template_url->url() == url) &&
+-      (template_url->data().suggestions_url == suggestion_url))
++      (template_url->keyword() == keyword) && (template_url->url() == url))
+     return;
+ 
+-  table_model_->ModifyTemplateURL(index.value(), title, keyword, url, suggestion_url);
++  table_model_->ModifyTemplateURL(index.value(), title, keyword, url);
+ 
+   base::RecordAction(UserMetricsAction("KeywordEditor_ModifiedKeyword"));
+ }
+diff --git a/chrome/browser/ui/search_engines/keyword_editor_controller.h b/chrome/browser/ui/search_engines/keyword_editor_controller.h
+index 4a3b1b06ff2b9..1cf89a2fa92df 100644
+--- a/chrome/browser/ui/search_engines/keyword_editor_controller.h
++++ b/chrome/browser/ui/search_engines/keyword_editor_controller.h
+@@ -33,16 +33,14 @@ class KeywordEditorController {
+   // model.  Returns the index of the added URL.
+   int AddTemplateURL(const std::u16string& title,
+                      const std::u16string& keyword,
+-                     const std::string& url,
+-                     const std::string& suggestion_url);
++                     const std::string& url);
+ 
+   // Invoked when the user modifies a TemplateURL. Updates the
+   // TemplateURLService and table model appropriately.
+   void ModifyTemplateURL(TemplateURL* template_url,
+                          const std::u16string& title,
+                          const std::u16string& keyword,
+-                         const std::string& url,
+-                         const std::string& suggestion_url);
++                         const std::string& url);
+ 
+   // Return true if the given |url| can be edited.
+   bool CanEdit(const TemplateURL* url) const;
+diff --git a/chrome/browser/ui/search_engines/template_url_table_model.cc b/chrome/browser/ui/search_engines/template_url_table_model.cc
+index 62ae300ff1436..bd107c525a973 100644
+--- a/chrome/browser/ui/search_engines/template_url_table_model.cc
++++ b/chrome/browser/ui/search_engines/template_url_table_model.cc
+@@ -200,8 +200,7 @@ void TemplateURLTableModel::Remove(size_t index) {
+ void TemplateURLTableModel::Add(size_t index,
+                                 const std::u16string& short_name,
+                                 const std::u16string& keyword,
+-                                const std::string& url,
+-                                const std::string& suggestion_url) {
++                                const std::string& url) {
+   DCHECK(index <= RowCount());
+   DCHECK(!url.empty());
+   TemplateURLData data;
+@@ -209,15 +208,13 @@ void TemplateURLTableModel::Add(size_t index,
+   data.SetKeyword(keyword);
+   data.SetURL(url);
+   data.is_active = TemplateURLData::ActiveStatus::kTrue;
+-  data.suggestions_url = suggestion_url;
+   template_url_service_->Add(std::make_unique<TemplateURL>(data));
+ }
+ 
+ void TemplateURLTableModel::ModifyTemplateURL(size_t index,
+                                               const std::u16string& title,
+                                               const std::u16string& keyword,
+-                                              const std::string& url,
+-                                              const std::string& suggestion_url) {
++                                              const std::string& url) {
+   DCHECK(index <= RowCount());
+   DCHECK(!url.empty());
+   TemplateURL* template_url = GetTemplateURL(index);
+@@ -226,7 +223,7 @@ void TemplateURLTableModel::ModifyTemplateURL(size_t index,
+   DCHECK(template_url_service_->GetDefaultSearchProvider() != template_url ||
+          template_url->SupportsReplacement(
+              template_url_service_->search_terms_data()));
+-  template_url_service_->ResetTemplateURL(template_url, title, keyword, url, suggestion_url);
++  template_url_service_->ResetTemplateURL(template_url, title, keyword, url);
+ }
+ 
+ TemplateURL* TemplateURLTableModel::GetTemplateURL(size_t index) {
+diff --git a/chrome/browser/ui/search_engines/template_url_table_model.h b/chrome/browser/ui/search_engines/template_url_table_model.h
+index 9cdc24b3238bf..aa6c76f61684d 100644
+--- a/chrome/browser/ui/search_engines/template_url_table_model.h
++++ b/chrome/browser/ui/search_engines/template_url_table_model.h
+@@ -61,15 +61,13 @@ class TemplateURLTableModel : public ui::TableModel,
+   void Add(size_t index,
+            const std::u16string& short_name,
+            const std::u16string& keyword,
+-           const std::string& url,
+-           const std::string& suggestion_url);
++           const std::string& url);
+ 
+   // Update the entry at the specified index.
+   void ModifyTemplateURL(size_t index,
+                          const std::u16string& title,
+                          const std::u16string& keyword,
+-                         const std::string& url,
+-                         const std::string& suggestion_url);
++                         const std::string& url);
+ 
+   // Reloads the icon at the specified index.
+   void ReloadIcon(size_t index);
+diff --git a/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc b/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
+index 446b0883f6332..be116b2d9d544 100644
+--- a/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
++++ b/chrome/browser/ui/webui/chrome_web_ui_controller_factory.cc
+@@ -127,8 +127,6 @@
+ #include "chrome/browser/ui/webui/webapks/webapks_ui.h"
+ #include "components/feed/buildflags.h"
+ #include "components/feed/feed_feature_list.h"
+-#include "chrome/browser/ui/webui/settings/settings_ui_android.h"
+-#include "chrome/browser/ui/webui/settings/settings_utils.h"
+ #else  // BUILDFLAG(IS_ANDROID)
+ #include "chrome/browser/media/router/discovery/access_code/access_code_cast_feature.h"
+ #include "chrome/browser/media/router/media_router_feature.h"
+@@ -598,10 +596,6 @@ WebUIFactoryFunction GetWebUIFactoryFunction(WebUI* web_ui,
+     return &NewWebUI<WebAppInternalsUI>;
+   }
+ #endif  // !BUILDFLAG(IS_ANDROID)
+-#if BUILDFLAG(IS_ANDROID)
+-  if (url.host_piece() == chrome::kChromeUISettingsHost)
+-    return &NewWebUI<settings::SettingsUI>;
+-#endif  // BUILDFLAG(IS_ANDROID)
+ #if BUILDFLAG(IS_WIN)
+   if (url.host_piece() == chrome::kChromeUIConflictsHost)
+     return &NewWebUI<ConflictsUI>;
+diff --git a/chrome/browser/ui/webui/favicon_source.cc b/chrome/browser/ui/webui/favicon_source.cc
+index cb567b50316f2..9024775236fbc 100644
+--- a/chrome/browser/ui/webui/favicon_source.cc
++++ b/chrome/browser/ui/webui/favicon_source.cc
+@@ -15,9 +15,7 @@
+ #include "chrome/browser/favicon/history_ui_favicon_request_handler_factory.h"
+ #include "chrome/browser/history/top_sites_factory.h"
+ #include "chrome/browser/profiles/profile.h"
+-#if !BUILDFLAG(IS_ANDROID)
+ #include "chrome/browser/search/instant_service.h"
+-#endif
+ #include "chrome/browser/ui/webui/webui_util_desktop.h"
+ #include "chrome/common/url_constants.h"
+ #include "chrome/common/webui_url_constants.h"
+@@ -26,11 +24,9 @@
+ #include "components/history/core/browser/top_sites.h"
+ #include "content/public/browser/browser_thread.h"
+ #include "content/public/browser/web_contents.h"
+-#if !BUILDFLAG(IS_ANDROID)
+ #include "extensions/browser/extension_registry.h"
+ #include "extensions/common/constants.h"
+ #include "extensions/common/manifest.h"
+-#endif
+ #include "third_party/skia/include/core/SkBitmap.h"
+ #include "ui/base/resource/resource_bundle.h"
+ #include "ui/base/resource/resource_scale_factor.h"
+@@ -212,22 +208,18 @@ bool FaviconSource::ShouldServiceRequest(
+     const GURL& url,
+     content::BrowserContext* browser_context,
+     int render_process_id) {
+-#if !BUILDFLAG(IS_ANDROID)
+   if (url.SchemeIs(chrome::kChromeSearchScheme)) {
+     return InstantService::ShouldServiceRequest(url, browser_context,
+                                                 render_process_id);
+   }
+-#endif
+   return URLDataSource::ShouldServiceRequest(url, browser_context,
+                                              render_process_id);
+ }
+ 
+-#if !BUILDFLAG(IS_ANDROID)
+ ui::NativeTheme* FaviconSource::GetNativeTheme(
+     const content::WebContents::Getter& wc_getter) {
+   return webui::GetNativeThemeDeprecated(wc_getter.Run());
+ }
+-#endif
+ 
+ void FaviconSource::OnFaviconDataAvailable(
+     content::URLDataSource::GotDataCallback callback,
+@@ -251,11 +243,7 @@ void FaviconSource::SendDefaultResponse(
+                         parsed.device_scale_factor,
+                         parsed.force_light_mode
+                             ? false
+-#if !BUILDFLAG(IS_ANDROID)
+                             : GetNativeTheme(wc_getter)->ShouldUseDarkColors());
+-#else
+-                            : false);
+-#endif
+     return;
+   }
+   int icon_size = std::ceil(parsed.size_in_dip * parsed.device_scale_factor);
+@@ -274,11 +262,7 @@ void FaviconSource::SendDefaultResponse(
+   SendDefaultResponse(std::move(callback), 16, 1.0f,
+                       force_light_mode
+                           ? false
+-#if !BUILDFLAG(IS_ANDROID)
+                           : GetNativeTheme(wc_getter)->ShouldUseDarkColors());
+-#else
+-                          : false);
+-#endif
+ }
+ 
+ void FaviconSource::SendDefaultResponse(
+@@ -288,7 +272,6 @@ void FaviconSource::SendDefaultResponse(
+     bool dark_mode) {
+   int resource_id;
+   switch (size_in_dip) {
+-#if !BUILDFLAG(IS_ANDROID)
+     case 64:
+       resource_id =
+           dark_mode ? IDR_DEFAULT_FAVICON_DARK_64 : IDR_DEFAULT_FAVICON_64;
+@@ -297,7 +280,6 @@ void FaviconSource::SendDefaultResponse(
+       resource_id =
+           dark_mode ? IDR_DEFAULT_FAVICON_DARK_32 : IDR_DEFAULT_FAVICON_32;
+       break;
+-#endif
+     default:
+       resource_id = dark_mode ? IDR_DEFAULT_FAVICON_DARK : IDR_DEFAULT_FAVICON;
+       break;
+diff --git a/chrome/browser/ui/webui/favicon_source.h b/chrome/browser/ui/webui/favicon_source.h
+index b90bdaf68d40e..d6b61d24c05a2 100644
+--- a/chrome/browser/ui/webui/favicon_source.h
++++ b/chrome/browser/ui/webui/favicon_source.h
+@@ -60,11 +60,9 @@ class FaviconSource : public content::URLDataSource {
+                             int render_process_id) override;
+ 
+  protected:
+-#if !BUILDFLAG(IS_ANDROID)
+   // Exposed for testing.
+   virtual ui::NativeTheme* GetNativeTheme(
+       const content::WebContents::Getter& wc_getter);
+-#endif
+   virtual base::RefCountedMemory* LoadIconBytes(float scale_factor,
+                                                 int resource_id);
+ 
+diff --git a/chrome/browser/ui/webui/settings/search_engines_handler.cc b/chrome/browser/ui/webui/settings/search_engines_handler.cc
+index 50c7a35b5ae59..3114eaedc6adb 100644
+--- a/chrome/browser/ui/webui/settings/search_engines_handler.cc
++++ b/chrome/browser/ui/webui/settings/search_engines_handler.cc
+@@ -33,12 +33,10 @@
+ #include "components/search_engines/template_url.h"
+ #include "components/search_engines/template_url_service.h"
+ #include "content/public/browser/web_ui.h"
+-#if !BUILDFLAG(IS_ANDROID)
+ #include "extensions/browser/extension_registry.h"
+ #include "extensions/browser/extension_system.h"
+ #include "extensions/browser/management_policy.h"
+ #include "extensions/common/extension.h"
+-#endif
+ 
+ #if BUILDFLAG(IS_CHROMEOS_ASH)
+ #include "ash/public/cpp/new_window_delegate.h"
+@@ -50,7 +48,6 @@ namespace {
+ const char kSearchEngineField[] = "searchEngine";
+ const char kKeywordField[] = "keyword";
+ const char kQueryUrlField[] = "queryUrl";
+-const char kSuggestionUrlField[] = "suggestionUrl";
+ 
+ // Dummy number used for indicating that a new search engine is added.
+ const int kNewSearchEngineIndex = -1;
+@@ -222,18 +219,15 @@ base::Value::Dict SearchEnginesHandler::CreateDictionaryForEngine(
+            table_model->GetText(index,
+                                 IDS_SEARCH_ENGINES_EDITOR_DESCRIPTION_COLUMN));
+   dict.Set("keyword", table_model->GetKeywordToDisplay(index));
++  Profile* profile = Profile::FromWebUI(web_ui());
+   dict.Set("url",
+            template_url->url_ref().DisplayURL(UIThreadSearchTermsData()));
+-  dict.Set("suggestionurl",
+-           template_url->suggestions_url_ref().DisplayURL(UIThreadSearchTermsData()));
+   dict.Set("urlLocked", ((template_url->prepopulate_id() > 0) ||
+                          (template_url->starter_pack_id() > 0)));
+   GURL icon_url = template_url->favicon_url();
+   if (icon_url.is_valid())
+     dict.Set("iconURL", icon_url.spec());
+ 
+-#if !BUILDFLAG(IS_ANDROID)
+-  Profile* profile = Profile::FromWebUI(web_ui());
+   const bool is_search_engine_choice_settings_ui =
+       search_engines::IsChoiceScreenFlagEnabled(
+           search_engines::ChoicePromo::kAny);
+@@ -257,7 +251,6 @@ base::Value::Dict SearchEnginesHandler::CreateDictionaryForEngine(
+       dict.Set("iconPath", base::StrCat({icon_path, "@2x"}));
+     }
+   }
+-#endif
+ 
+   dict.Set("modelIndex", base::checked_cast<int>(index));
+ 
+@@ -274,7 +267,6 @@ base::Value::Dict SearchEnginesHandler::CreateDictionaryForEngine(
+   dict.Set("isOmniboxExtension", type == TemplateURL::OMNIBOX_API_EXTENSION);
+   dict.Set("isPrepopulated", template_url->prepopulate_id() > 0);
+   dict.Set("isStarterPack", template_url->starter_pack_id() > 0);
+-#if !BUILDFLAG(IS_ANDROID)
+   if (type == TemplateURL::NORMAL_CONTROLLED_BY_EXTENSION ||
+       type == TemplateURL::OMNIBOX_API_EXTENSION) {
+     const extensions::Extension* extension =
+@@ -291,7 +283,6 @@ base::Value::Dict SearchEnginesHandler::CreateDictionaryForEngine(
+       dict.Set("extension", std::move(ext_info));
+     }
+   }
+-#endif
+   return dict;
+ }
+ 
+@@ -372,13 +363,12 @@ void SearchEnginesHandler::HandleSearchEngineEditStarted(
+ void SearchEnginesHandler::OnEditedKeyword(TemplateURL* template_url,
+                                            const std::u16string& title,
+                                            const std::u16string& keyword,
+-                                           const std::string& url,
+-                                           const std::string& suggestion_url) {
++                                           const std::string& url) {
+   DCHECK(!url.empty());
+   if (template_url)
+-    list_controller_.ModifyTemplateURL(template_url, title, keyword, url, suggestion_url);
++    list_controller_.ModifyTemplateURL(template_url, title, keyword, url);
+   else
+-    list_controller_.AddTemplateURL(title, keyword, url, suggestion_url);
++    list_controller_.AddTemplateURL(title, keyword, url);
+ 
+   edit_controller_.reset();
+ }
+@@ -406,8 +396,6 @@ bool SearchEnginesHandler::CheckFieldValidity(const std::string& field_name,
+     is_valid = edit_controller_->IsKeywordValid(base::UTF8ToUTF16(field_value));
+   else if (field_name.compare(kQueryUrlField) == 0)
+     is_valid = edit_controller_->IsURLValid(field_value);
+-  else if (field_name.compare(kSuggestionUrlField) == 0)
+-    is_valid = field_value.empty() || edit_controller_->IsURLValid(field_value);
+   else
+     NOTREACHED_IN_MIGRATION();
+ 
+@@ -427,20 +415,18 @@ void SearchEnginesHandler::HandleSearchEngineEditCompleted(
+   if (!edit_controller_.get())
+     return;
+ 
+-  CHECK_EQ(4U, args.size());
++  CHECK_EQ(3U, args.size());
+   const std::string& search_engine = args[0].GetString();
+   const std::string& keyword = args[1].GetString();
+   const std::string& query_url = args[2].GetString();
+-  const std::string& suggestion_url = args[3].GetString();
+ 
+   // Recheck validity. It's possible to get here with invalid input if e.g. the
+   // user calls the right JS functions directly from the web inspector.
+   if (CheckFieldValidity(kSearchEngineField, search_engine) &&
+       CheckFieldValidity(kKeywordField, keyword) &&
+-      CheckFieldValidity(kQueryUrlField, query_url) &&
+-      CheckFieldValidity(kSuggestionUrlField, suggestion_url)) {
++      CheckFieldValidity(kQueryUrlField, query_url)) {
+     edit_controller_->AcceptAddOrEdit(base::UTF8ToUTF16(search_engine),
+-                                      base::UTF8ToUTF16(keyword), query_url, suggestion_url);
++                                      base::UTF8ToUTF16(keyword), query_url);
+   }
+ }
+ 
+diff --git a/chrome/browser/ui/webui/settings/search_engines_handler.h b/chrome/browser/ui/webui/settings/search_engines_handler.h
+index fcae0cffb982b..616bfb211a2df 100644
+--- a/chrome/browser/ui/webui/settings/search_engines_handler.h
++++ b/chrome/browser/ui/webui/settings/search_engines_handler.h
+@@ -41,8 +41,7 @@ class SearchEnginesHandler : public SettingsPageUIHandler,
+   void OnEditedKeyword(TemplateURL* template_url,
+                        const std::u16string& title,
+                        const std::u16string& keyword,
+-                       const std::string& url,
+-                       const std::string& suggestion_url) override;
++                       const std::string& url) override;
+ 
+   // SettingsPageUIHandler implementation.
+   void RegisterMessages() override;
+diff --git a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+index 3f08cf9f9dd85..bfe218322d526 100644
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -2410,8 +2410,6 @@ void AddSearchEnginesStrings(content::WebUIDataSource* html_source) {
+       {"searchEnginesQueryURL", IDS_SETTINGS_SEARCH_ENGINES_QUERY_URL},
+       {"searchEnginesQueryURLExplanation",
+        IDS_SETTINGS_SEARCH_ENGINES_QUERY_URL_EXPLANATION},
+-      {"searchEnginesSuggestionURLExplanation",
+-       IDS_SETTINGS_SEARCH_ENGINES_SUGGESTION_URL_EXPLANATION},
+       {"searchEnginesMakeDefault", IDS_SETTINGS_SEARCH_ENGINES_MAKE_DEFAULT},
+       {"searchEnginesActivate", IDS_SETTINGS_SEARCH_ENGINES_ACTIVATE},
+       {"searchEnginesDeactivate", IDS_SETTINGS_SEARCH_ENGINES_DEACTIVATE},
+@@ -3716,12 +3714,6 @@ void AddLocalizedStrings(content::WebUIDataSource* html_source,
+   AddSystemStrings(html_source);
+ #endif
+ 
+-#if BUILDFLAG(IS_ANDROID)
+-  html_source->AddString("chromeAndroid", "chrome-android");
+-#else
+-  html_source->AddString("chromeAndroid", "");
+-#endif
+-
+ #if BUILDFLAG(USE_NSS_CERTS)
+   certificate_manager::AddLocalizedStrings(html_source);
+ #endif
+diff --git a/chrome/browser/ui/webui/settings/settings_localized_strings_provider_android.cc b/chrome/browser/ui/webui/settings/settings_localized_strings_provider_android.cc
+deleted file mode 100644
+index 6cd329f590ee2..0000000000000
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider_android.cc
++++ /dev/null
+@@ -1,198 +0,0 @@
+-#include "chrome/browser/ui/webui/settings/settings_localized_strings_provider.h"
+-
+-#include <string>
+-
+-#include "base/command_line.h"
+-#include "base/feature_list.h"
+-#include "base/i18n/message_formatter.h"
+-#include "base/i18n/number_formatting.h"
+-#include "base/strings/escape.h"
+-#include "base/strings/string_number_conversions.h"
+-#include "base/strings/utf_string_conversions.h"
+-#include "base/json/json_writer.h"
+-#include "build/branding_buildflags.h"
+-#include "build/build_config.h"
+-#include "build/buildflag.h"
+-#include "build/chromeos_buildflags.h"
+-#include "chrome/browser/ui/webui/settings/shared_settings_localized_strings_provider.h"
+-#include "chrome/browser/ui/webui/version/version_ui.h"
+-#include "chrome/grit/branded_strings.h"
+-#include "chrome/grit/generated_resources.h"
+-#include "chrome/grit/locale_settings.h"
+-#include "ui/base/l10n/l10n_util.h"
+-#include "ui/strings/grit/ui_strings.h"
+-
+-namespace settings {
+-namespace {
+-
+-inline constexpr char16_t kSettingsSearchHelpURL[] =
+-    u"https://nourl";
+-
+-void AddCommonStrings(content::WebUIDataSource* html_source, Profile* profile) {
+-  static constexpr webui::LocalizedString kLocalizedStrings[] = {
+-    {"add", IDS_ADD2},
+-    {"advancedPageTitle", IDS_SETTINGS_ADVANCED},
+-    {"back", IDS_ACCNAME_BACK2},
+-    {"basicPageTitle", IDS_SETTINGS_BASIC},
+-    {"cancel", IDS_CANCEL2},
+-    {"clear", IDS_SETTINGS_CLEAR},
+-    {"close", IDS_CLOSE2},
+-    {"confirm", IDS_CONFIRM},
+-    {"continue", IDS_SETTINGS_CONTINUE},
+-    {"controlledByExtension", IDS_SETTINGS_CONTROLLED_BY_EXTENSION},
+-    {"custom", IDS_SETTINGS_CUSTOM},
+-    {"delete", IDS_SETTINGS_DELETE},
+-    {"disable", IDS_DISABLE},
+-    {"done", IDS_DONE2},
+-    {"edit", IDS_SETTINGS_EDIT},
+-    {"extensionsLinkTooltip", IDS_SETTINGS_MENU_EXTENSIONS_LINK_TOOLTIP},
+-    {"fonts", IDS_SETTINGS_FONTS},
+-    {"learnMore", IDS_LEARN_MORE2},
+-    {"manage", IDS_SETTINGS_MANAGE},
+-    {"menu", IDS_MENU2},
+-    {"menuButtonLabel", IDS_SETTINGS_MENU_BUTTON_LABEL},
+-    {"moreActions", IDS_SETTINGS_MORE_ACTIONS},
+-    {"noThanks", IDS_NO_THANKS2},
+-    {"ok", IDS_OK2},
+-    {"opensInNewTab", IDS_SETTINGS_OPENS_IN_NEW_TAB},
+-    {"sendFeedbackButton", IDS_SETTINGS_SEND_FEEDBACK_ROLE_DESCRIPTION},
+-    //{"relaunchConfirmationDialogTitle", IDS_RELAUNCH_CONFIRMATION_DIALOG_TITLE},
+-    {"remove", IDS_REMOVE2},
+-    {"restart", IDS_SETTINGS_RESTART},
+-    //{"restartToApplyChanges", IDS_SETTINGS_RESTART_TO_APPLY_CHANGES},
+-    {"retry", IDS_SETTINGS_RETRY},
+-    {"save", IDS_SAVE2},
+-    //{"searchResultBubbleText", IDS_SEARCH_RESULT_BUBBLE_TEXT},
+-    //{"searchResultsBubbleText", IDS_SEARCH_RESULTS_BUBBLE_TEXT},
+-    {"sentenceEnd", IDS_SENTENCE_END},
+-    {"settings", IDS_SETTINGS_SETTINGS},
+-    {"settingsAltPageTitle", IDS_SETTINGS_ALT_PAGE_TITLE},
+-    {"subpageArrowRoleDescription", IDS_SETTINGS_SUBPAGE_BUTTON},
+-    {"subpageBackButtonAriaLabel", IDS_SETTINGS_SUBPAGE_BACK_BUTTON_ARIA_LABEL},
+-    {"subpageBackButtonAriaRoleDescription",
+-     IDS_SETTINGS_SUBPAGE_BACK_BUTTON_ARIA_ROLE_DESCRIPTION},
+-    {"subpageLearnMoreAriaLabel", IDS_SETTINGS_SUBPAGE_LEARN_MORE_ARIA_LABEL},
+-    {"notValid", IDS_SETTINGS_NOT_VALID},
+-    {"notValidWebAddress", IDS_SETTINGS_NOT_VALID_WEB_ADDRESS},
+-    {"notValidWebAddressForContentType",
+-     IDS_SETTINGS_NOT_VALID_WEB_ADDRESS_FOR_CONTENT_TYPE},
+-  };
+-  html_source->AddLocalizedStrings(kLocalizedStrings);
+-
+-  html_source->AddBoolean(
+-      "isGuest", false);
+-
+-  html_source->AddBoolean("isChildAccount", false);
+-
+-  html_source->AddBoolean(
+-      "clearingCookiesKeepsSupervisedUsersSignedIn",
+-      false);
+-
+-  html_source->AddBoolean("allowQtTheme", false);
+-}
+-
+-void AddSearchEnginesStrings(content::WebUIDataSource* html_source) {
+-  static constexpr webui::LocalizedString kLocalizedStrings[] = {
+-      {"searchEnginesPageExplanation",
+-       IDS_SETTINGS_SEARCH_ENGINES_PAGE_EXPLANATION},
+-      {"searchEnginesAddSearchEngine",
+-       IDS_SETTINGS_SEARCH_ENGINES_ADD_SEARCH_ENGINE},
+-      {"searchEnginesEditSearchEngine",
+-       IDS_SETTINGS_SEARCH_ENGINES_EDIT_SEARCH_ENGINE},
+-      {"searchEnginesDeleteConfirmationTitle",
+-       IDS_SETTINGS_SEARCH_ENGINES_DELETE_CONFIRMATION_TITLE},
+-      {"searchEnginesDeleteConfirmationDescription",
+-       IDS_SETTINGS_SEARCH_ENGINES_DELETE_CONFIRMATION_DESCRIPTION},
+-      {"searchEngines", IDS_SETTINGS_SEARCH_ENGINES},
+-      {"searchEnginesSearchEngines",
+-       IDS_SETTINGS_SEARCH_ENGINES_SEARCH_ENGINES},
+-      {"searchEnginesSearchEnginesExplanation",
+-       IDS_SETTINGS_SEARCH_ENGINES_SEARCH_ENGINES_EXPLANATION},
+-      {"searchEnginesSiteSearch", IDS_SETTINGS_SEARCH_ENGINES_SITE_SEARCH},
+-      {"searchEnginesSiteSearchExplanation",
+-       IDS_SETTINGS_SEARCH_ENGINES_SITE_SEARCH_EXPLANATION},
+-      {"searchEnginesNoSitesAdded", IDS_SETTINGS_SEARCH_ENGINES_NO_SITES_ADDED},
+-      {"searchEnginesInactiveShortcuts",
+-       IDS_SETTINGS_SEARCH_ENGINES_INACTIVE_SHORTCUTS},
+-      {"searchEnginesNoOtherEngines",
+-       IDS_SETTINGS_SEARCH_ENGINES_NO_OTHER_ENGINES},
+-      {"searchEnginesExtension", IDS_SETTINGS_SEARCH_ENGINES_EXTENSION_ENGINES},
+-      {"searchEnginesExtensionExplanation",
+-       IDS_SETTINGS_SEARCH_ENGINES_EXTENSION_ENGINES_EXPLANATION},
+-      {"searchEnginesSearch", IDS_SETTINGS_SEARCH_ENGINES_SEARCH},
+-      {"searchEnginesName", IDS_SETTINGS_SEARCH_ENGINES_NAME},
+-      {"searchEnginesSearchEngine", IDS_SETTINGS_SEARCH_ENGINES_SEARCH_ENGINE},
+-      {"searchEnginesSiteOrPage", IDS_SETTINGS_SEARCH_ENGINES_SITE_OR_PAGE},
+-      {"searchEnginesShortcut", IDS_SETTINGS_SEARCH_ENGINES_SHORTCUT},
+-      {"searchEnginesQueryURL", IDS_SETTINGS_SEARCH_ENGINES_QUERY_URL},
+-      {"searchEnginesQueryURLExplanation",
+-       IDS_SETTINGS_SEARCH_ENGINES_QUERY_URL_EXPLANATION},
+-      {"searchEnginesSuggestionURLExplanation",
+-       IDS_SETTINGS_SEARCH_ENGINES_SUGGESTION_URL_EXPLANATION},
+-      {"searchEnginesMakeDefault", IDS_SETTINGS_SEARCH_ENGINES_MAKE_DEFAULT},
+-      {"searchEnginesActivate", IDS_SETTINGS_SEARCH_ENGINES_ACTIVATE},
+-      {"searchEnginesDeactivate", IDS_SETTINGS_SEARCH_ENGINES_DEACTIVATE},
+-      {"searchEnginesManageExtension",
+-       IDS_SETTINGS_SEARCH_ENGINES_MANAGE_EXTENSION},
+-      {"searchEnginesKeyboardShortcutsTitle",
+-       IDS_SETTINGS_SEARCH_ENGINES_KEYBOARD_SHORTCUTS_TITLE},
+-      {"searchEnginesKeyboardShortcutsDescription",
+-       IDS_SETTINGS_SEARCH_ENGINES_KEYBOARD_SHORTCUTS_DESCRIPTION},
+-      {"searchEnginesKeyboardShortcutsSpaceOrTab",
+-       IDS_SETTINGS_SEARCH_ENGINES_KEYBOARD_SHORTCUTS_SPACE_OR_TAB},
+-      {"searchEnginesKeyboardShortcutsTab",
+-       IDS_SETTINGS_SEARCH_ENGINES_KEYBOARD_SHORTCUTS_TAB},
+-      {"searchEnginesAdditionalSites",
+-       IDS_SETTINGS_SEARCH_ENGINES_ADDITIONAL_SITES},
+-      {"searchEnginesAdditionalInactiveSites",
+-       IDS_SETTINGS_SEARCH_ENGINES_ADDITIONAL_INACTIVE_SITES},
+-  };
+-  html_source->AddLocalizedStrings(kLocalizedStrings);
+-}
+-
+-void AddSearchStrings(content::WebUIDataSource* html_source) {
+-  static constexpr webui::LocalizedString kLocalizedStrings[] = {
+-    {"searchEnginesManage", IDS_SETTINGS_SEARCH_MANAGE_SEARCH_ENGINES},
+-    {"searchEnginesManageSiteSearch",
+-     IDS_SETTINGS_SEARCH_MANAGE_SEARCH_ENGINES_AND_SITE_SEARCH},
+-    {"searchPageTitle", IDS_SETTINGS_SEARCH},
+-    {"searchExplanation", IDS_SETTINGS_SEARCH_EXPLANATION},
+-    {"searchExplanationLearnMoreA11yLabel",
+-     IDS_SETTINGS_SEARCH_EXPLANATION_ACCESSIBILITY_LABEL},
+-  };
+-  html_source->AddLocalizedStrings(kLocalizedStrings);
+-
+-  html_source->AddString("searchExplanationLearnMoreURL",
+-                         "");
+-}
+-
+-void AddSearchInSettingsStrings(content::WebUIDataSource* html_source) {
+-  static constexpr webui::LocalizedString kLocalizedStrings[] = {
+-      {"searchPrompt", IDS_SETTINGS_SEARCH_PROMPT},
+-      {"searchNoResults", IDS_SEARCH_NO_RESULTS},
+-      {"searchResults", IDS_SEARCH_RESULTS},
+-      {"clearSearch", IDS_CLEAR_SEARCH},
+-  };
+-  html_source->AddLocalizedStrings(kLocalizedStrings);
+-
+-  std::u16string help_text = l10n_util::GetStringFUTF16(
+-      IDS_SETTINGS_SEARCH_NO_RESULTS_HELP, kSettingsSearchHelpURL);
+-  html_source->AddString("searchNoResultsHelp", help_text);
+-}
+-
+-}  // namespace
+-
+-void AddLocalizedStringsAndroid(content::WebUIDataSource* html_source,
+-                                Profile* profile,
+-                                content::WebContents* web_contents) {
+-  html_source->AddString("chromeAndroid", "chrome-android");
+-  AddCommonStrings(html_source, profile);
+-  AddSearchStrings(html_source);
+-  AddSearchEnginesStrings(html_source);
+-  AddSearchInSettingsStrings(html_source);
+-  html_source->AddString("check_notfound", "false");
+-  html_source->AddInteger("br_cs_count", 0);
+-  html_source->UseStringsJs();
+-}
+-
+-}  // namespace settings
+diff --git a/chrome/browser/ui/webui/settings/settings_localized_strings_provider_android.h b/chrome/browser/ui/webui/settings/settings_localized_strings_provider_android.h
+deleted file mode 100644
+index 09b177ac2aa20..0000000000000
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider_android.h
++++ /dev/null
+@@ -1,19 +0,0 @@
+-#ifndef CHROME_BROWSER_UI_WEBUI_SETTINGS_SETTINGS_LOCALIZED_STRINGS_PROVIDER_ANDROID_H_
+-#define CHROME_BROWSER_UI_WEBUI_SETTINGS_SETTINGS_LOCALIZED_STRINGS_PROVIDER_ANDROID_H_
+-
+-class Profile;
+-
+-namespace content {
+-class WebUIDataSource;
+-class WebContents;
+-}
+-
+-namespace settings {
+-
+-void AddLocalizedStringsAndroid(content::WebUIDataSource* html_source,
+-                                Profile* profile,
+-                                content::WebContents* web_contents);
+-
+-}  // namespace settings
+-
+-#endif  // CHROME_BROWSER_UI_WEBUI_SETTINGS_SETTINGS_LOCALIZED_STRINGS_PROVIDER_ANDROID_H_
+diff --git a/chrome/browser/ui/webui/settings/settings_ui_android.cc b/chrome/browser/ui/webui/settings/settings_ui_android.cc
+deleted file mode 100644
+index 1c605ed0ae8fc..0000000000000
+--- a/chrome/browser/ui/webui/settings/settings_ui_android.cc
++++ /dev/null
+@@ -1,134 +0,0 @@
+-// Copyright 2015 The Chromium Authors
+-// Use of this source code is governed by a BSD-style license that can be
+-// found in the LICENSE file.
+-
+-#include "chrome/browser/ui/webui/settings/settings_ui_android.h"
+-
+-#include <stddef.h>
+-
+-#include <memory>
+-#include <string>
+-#include <utility>
+-#include <vector>
+-
+-#include "base/feature_list.h"
+-#include "base/memory/ptr_util.h"
+-#include "build/branding_buildflags.h"
+-#include "build/build_config.h"
+-#include "build/chromeos_buildflags.h"
+-#include "chrome/browser/profiles/profile.h"
+-#include "chrome/browser/ui/ui_features.h"
+-#include "chrome/browser/ui/webui/favicon_source.h"
+-#include "chrome/browser/ui/webui/settings/search_engines_handler.h"
+-#include "chrome/common/chrome_features.h"
+-#include "chrome/common/pref_names.h"
+-#include "chrome/common/url_constants.h"
+-#include "chrome/grit/branded_strings.h"
+-#include "chrome/grit/generated_resources.h"
+-#include "chrome/grit/settings_resources.h"
+-#include "chrome/grit/settings_resources_map.h"
+-#include "components/favicon_base/favicon_url_parser.h"
+-#include "components/permissions/features.h"
+-#include "components/pref_registry/pref_registry_syncable.h"
+-#include "components/prefs/pref_service.h"
+-#include "content/public/browser/url_data_source.h"
+-#include "content/public/browser/web_contents.h"
+-#include "content/public/browser/web_ui.h"
+-#include "content/public/browser/web_ui_data_source.h"
+-#include "crypto/crypto_buildflags.h"
+-#include "services/network/public/cpp/features.h"
+-#include "third_party/blink/public/common/features.h"
+-#include "ui/base/interaction/element_identifier.h"
+-
+-#include "chrome/browser/ui/webui/webui_util.h"
+-#include "chrome/browser/ui/webui/theme_handler.h"
+-#include "chrome/browser/ui/webui/cr_components/customize_color_scheme_mode/customize_color_scheme_mode_handler.h"
+-#include "chrome/browser/ui/webui/customize_themes/chrome_customize_themes_handler.h"
+-#include "chrome/browser/ui/webui/settings/settings_localized_strings_provider_android.h"
+-
+-#if !BUILDFLAG(OPTIMIZE_WEBUI)
+-#include "chrome/grit/settings_shared_resources.h"
+-#include "chrome/grit/settings_shared_resources_map.h"
+-#endif
+-
+-#include "chrome/browser/ui/webui/cr_components/theme_color_picker/theme_color_picker_handler.h"
+-#include "chrome/browser/ui/webui/settings/captions_handler.h"
+-#include "chrome/browser/ui/webui/settings/settings_default_browser_handler.h"
+-#include "chrome/browser/ui/webui/settings/settings_manage_profile_handler.h"
+-#include "chrome/browser/ui/webui/settings/system_handler.h"
+-
+-namespace settings {
+-
+-SettingsUI::SettingsUI(content::WebUI* web_ui)
+-    : ui::MojoWebUIController(web_ui, /*enable_chrome_send=*/true) {
+-  Profile* profile = Profile::FromWebUI(web_ui);
+-  content::WebUIDataSource* html_source =
+-      content::WebUIDataSource::CreateAndAdd(
+-          web_ui->GetWebContents()->GetBrowserContext(),
+-          chrome::kChromeUISettingsHost);
+-  html_source->OverrideContentSecurityPolicy(
+-      network::mojom::CSPDirectiveName::WorkerSrc,
+-      "worker-src blob: chrome://resources 'self';");
+-
+-  AddSettingsPageUIHandler(std::make_unique<SearchEnginesHandler>(profile));
+-  web_ui->DoNotCrashOnUnhandledMessage();
+-
+-  webui::SetupWebUIDataSource(
+-      html_source, base::make_span(kSettingsResources, kSettingsResourcesSize),
+-      IDR_SETTINGS_SETTINGS_HTML);
+-
+-  html_source->AddBoolean(
+-      "enablePageContentSetting",
+-      false);
+-
+-#if !BUILDFLAG(OPTIMIZE_WEBUI)
+-  html_source->AddResourcePaths(
+-      base::make_span(kSettingsSharedResources, kSettingsSharedResourcesSize));
+-#endif
+-
+-  AddLocalizedStringsAndroid(html_source, profile, web_ui->GetWebContents());
+-
+-  content::URLDataSource::Add(
+-      profile, std::make_unique<FaviconSource>(
+-                   profile, chrome::FaviconUrlFormat::kFavicon2));
+-}
+-
+-SettingsUI::~SettingsUI() = default;
+-
+-void SettingsUI::AddSettingsPageUIHandler(
+-    std::unique_ptr<content::WebUIMessageHandler> handler) {
+-  DCHECK(handler);
+-  web_ui()->AddMessageHandler(std::move(handler));
+-}
+-
+-void SettingsUI::CreateCustomizeThemesHandler(
+-    mojo::PendingRemote<customize_themes::mojom::CustomizeThemesClient>
+-        pending_client,
+-    mojo::PendingReceiver<customize_themes::mojom::CustomizeThemesHandler>
+-        pending_handler) {
+-}
+-
+-void SettingsUI::CreateThemeColorPickerHandler(
+-    mojo::PendingReceiver<theme_color_picker::mojom::ThemeColorPickerHandler>
+-        handler,
+-    mojo::PendingRemote<theme_color_picker::mojom::ThemeColorPickerClient>
+-        client) {
+-}
+-
+-void SettingsUI::CreateHelpBubbleHandler(
+-    mojo::PendingRemote<help_bubble::mojom::HelpBubbleClient> client,
+-    mojo::PendingReceiver<help_bubble::mojom::HelpBubbleHandler> handler) {
+-}
+-
+-void SettingsUI::BindInterface(
+-    mojo::PendingReceiver<help_bubble::mojom::HelpBubbleHandlerFactory>
+-        pending_receiver) {}
+-
+-void SettingsUI::BindInterface(
+-    mojo::PendingReceiver<customize_color_scheme_mode::mojom::
+-                            CustomizeColorSchemeModeHandlerFactory>
+-        pending_receiver) {}
+-
+-WEB_UI_CONTROLLER_TYPE_IMPL(SettingsUI)
+-
+-}  // namespace settings
+diff --git a/chrome/browser/ui/webui/settings/settings_ui_android.h b/chrome/browser/ui/webui/settings/settings_ui_android.h
+deleted file mode 100644
+index 03b086a08b6b5..0000000000000
+--- a/chrome/browser/ui/webui/settings/settings_ui_android.h
++++ /dev/null
+@@ -1,119 +0,0 @@
+-#ifndef CHROME_BROWSER_UI_WEBUI_SETTINGS_SETTINGS_UI_ANDROID_H_
+-#define CHROME_BROWSER_UI_WEBUI_SETTINGS_SETTINGS_UI_ANDROID_H_
+-
+-#include "build/build_config.h"
+-#include "build/chromeos_buildflags.h"
+-#include "chrome/browser/profiles/profile.h"
+-#include "components/user_education/webui/help_bubble_handler.h"
+-#include "content/public/browser/web_ui_controller.h"
+-#include "mojo/public/cpp/bindings/pending_receiver.h"
+-#include "mojo/public/cpp/bindings/pending_remote.h"
+-#include "mojo/public/cpp/bindings/receiver.h"
+-#include "ui/webui/mojo_web_ui_controller.h"
+-#include "ui/webui/resources/cr_components/customize_color_scheme_mode/customize_color_scheme_mode.mojom.h"
+-#include "ui/webui/resources/cr_components/help_bubble/help_bubble.mojom.h"
+-
+-#if !BUILDFLAG(IS_CHROMEOS_ASH)
+-#include "ui/webui/resources/cr_components/customize_themes/customize_themes.mojom.h"
+-#include "ui/webui/resources/cr_components/theme_color_picker/theme_color_picker.mojom.h"
+-#endif  // !BUILDFLAG(IS_CHROMEOS_ASH)
+-
+-namespace content {
+-class WebUIMessageHandler;
+-}  // namespace content
+-
+-namespace user_prefs {
+-class PrefRegistrySyncable;
+-}
+-
+-#if !BUILDFLAG(IS_CHROMEOS_ASH)
+-class ChromeCustomizeThemesHandler;
+-class ThemeColorPickerHandler;
+-#endif  // !BUILDFLAG(IS_CHROMEOS_ASH)
+-
+-class CustomizeColorSchemeModeHandler;
+-namespace settings {
+-
+-// The WebUI handler for chrome://settings.
+-class SettingsUI
+-    : public ui::MojoWebUIController,
+-      public help_bubble::mojom::HelpBubbleHandlerFactory
+-    // public customize_color_scheme_mode::mojom::CustomizeColorSchemeModeHandlerFactory
+-#if !BUILDFLAG(IS_CHROMEOS_ASH)
+-    // chrome://settings/manageProfile which only exists on !OS_CHROMEOS
+-    // requires mojo bindings.
+-    ,
+-      public customize_themes::mojom::CustomizeThemesHandlerFactory,
+-      public theme_color_picker::mojom::ThemeColorPickerHandlerFactory
+-#endif  // BUILDFLAG(IS_CHROMEOS_ASH)
+-{
+- public:
+-  static void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry);
+-
+-  explicit SettingsUI(content::WebUI* web_ui);
+-
+-  SettingsUI(const SettingsUI&) = delete;
+-  SettingsUI& operator=(const SettingsUI&) = delete;
+-
+-  ~SettingsUI() override;
+-
+-#if !BUILDFLAG(IS_CHROMEOS_ASH)
+-  // Instantiates the implementor of the
+-  // customize_themes::mojom::CustomizeThemesHandlerFactory mojo interface
+-  // passing the pending receiver that will be internally bound.
+-  void BindInterface(mojo::PendingReceiver<
+-                     customize_themes::mojom::CustomizeThemesHandlerFactory>
+-                         pending_receiver);
+-
+-  // Instantiates the implementor of the
+-  // theme_color_picker::mojom::ThemeColorPickerHandlerFactory mojo interface
+-  // passing the pending receiver that will be internally bound.
+-  void BindInterface(mojo::PendingReceiver<
+-                     theme_color_picker::mojom::ThemeColorPickerHandlerFactory>
+-                         pending_receiver);
+-#endif  // !BUILDFLAG(IS_CHROMEOS_ASH)
+-
+-  // Implements support for help bubbles (IPH, tutorials, etc.) in settings
+-  // pages.
+-  void BindInterface(
+-      mojo::PendingReceiver<help_bubble::mojom::HelpBubbleHandlerFactory>
+-          pending_receiver);
+-
+-  void BindInterface(
+-      mojo::PendingReceiver<customize_color_scheme_mode::mojom::
+-                                CustomizeColorSchemeModeHandlerFactory>
+-          pending_receiver);
+-
+- private:
+-  void AddSettingsPageUIHandler(
+-      std::unique_ptr<content::WebUIMessageHandler> handler);
+-
+-#if !BUILDFLAG(IS_CHROMEOS_ASH)
+-  // customize_themes::mojom::CustomizeThemesHandlerFactory:
+-  void CreateCustomizeThemesHandler(
+-      mojo::PendingRemote<customize_themes::mojom::CustomizeThemesClient>
+-          pending_client,
+-      mojo::PendingReceiver<customize_themes::mojom::CustomizeThemesHandler>
+-          pending_handler) override;
+-
+-  // theme_color_picker::mojom::ThemeColorPickerHandlerFactory:
+-  void CreateThemeColorPickerHandler(
+-      mojo::PendingReceiver<theme_color_picker::mojom::ThemeColorPickerHandler>
+-          handler,
+-      mojo::PendingRemote<theme_color_picker::mojom::ThemeColorPickerClient>
+-          client) override;
+-
+-#endif  // !BUILDFLAG(IS_CHROMEOS_ASH)
+-
+-  // help_bubble::mojom::HelpBubbleHandlerFactory:
+-  void CreateHelpBubbleHandler(
+-      mojo::PendingRemote<help_bubble::mojom::HelpBubbleClient> client,
+-      mojo::PendingReceiver<help_bubble::mojom::HelpBubbleHandler> handler)
+-      override;
+-
+-  WEB_UI_CONTROLLER_TYPE_DECL();
+-};
+-
+-}  // namespace settings
+-
+-#endif  // CHROME_BROWSER_UI_WEBUI_SETTINGS_SETTINGS_UI_ANDROID_H_
+diff --git a/chrome/chrome_paks.gni b/chrome/chrome_paks.gni
+index ae6df5ff2154d..fedb3c973f33b 100644
+--- a/chrome/chrome_paks.gni
++++ b/chrome/chrome_paks.gni
+@@ -156,17 +156,6 @@ template("chrome_extra_paks") {
+       sources += invoker.additional_paks
+     }
+ 
+-    if (is_android) {
+-      sources += [
+-        "$root_gen_dir/chrome/settings_resources.pak",
+-      ]
+-      if (!optimize_webui) {
+-        # Only add when optimize_webui=false, since in other cases the same
+-        # resources are already bundled within the UIs that use them.
+-        sources += [ "$root_gen_dir/chrome/settings_shared_resources.pak" ]
+-        deps += [ "//chrome/browser/resources/settings_shared:resources" ]
+-      }
+-    }
+     if (!is_android) {
+       # New paks should be added here by default.
+       sources += [
+diff --git a/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/SettingsLauncher.java b/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/SettingsLauncher.java
+index c7ca544c5ae37..9fa08ed815500 100644
+--- a/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/SettingsLauncher.java
++++ b/components/browser_ui/settings/android/java/src/org/chromium/components/browser_ui/settings/SettingsLauncher.java
+@@ -53,8 +53,6 @@ public interface SettingsLauncher {
+         int MANAGE_SYNC = 9;
+     }
+ 
+-    void launchUrlInCustomTab(Context context, String url);
+-
+     /**
+      * Launches a Settings Activity with the default (top-level) fragment.
+      *
+diff --git a/components/browser_ui/strings/bromite_content_settings/search_engine_desktop_ui.grdp b/components/browser_ui/strings/bromite_content_settings/search_engine_desktop_ui.grdp
+deleted file mode 100644
+index be9492cbc2450..0000000000000
+--- a/components/browser_ui/strings/bromite_content_settings/search_engine_desktop_ui.grdp
++++ /dev/null
+@@ -1,6 +0,0 @@
+-<?xml version="1.0" encoding="utf-8"?>
+-<grit-part>
+-  <message name="IDS_SEARCH_ENGINE_OPEN_DESKTOP_UI" desc="" formatter_data="android_java">
+-    Edit search engines
+-  </message>
+-</grit-part>
+diff --git a/components/search_engines/android/template_url_service_android.cc b/components/search_engines/android/template_url_service_android.cc
+index ddad9b5004f82..3bddb187b2289 100644
+--- a/components/search_engines/android/template_url_service_android.cc
++++ b/components/search_engines/android/template_url_service_android.cc
+@@ -419,7 +419,7 @@ jboolean TemplateUrlServiceAndroid::SetPlayAPISearchEngine(
+     if (existing_play_api_turl->safe_for_autoreplace()) {
+       template_url_service_->ResetTemplateURL(
+           existing_play_api_turl, existing_play_api_turl->short_name(),
+-          existing_play_api_turl->keyword(), existing_play_api_turl->url(), /*suggestion_url*/ "");
++          existing_play_api_turl->keyword(), existing_play_api_turl->url());
+     }
+ 
+     // Only one search engine can be marked as coming from Play at a time.
+diff --git a/components/search_engines/search_engines_switches.cc b/components/search_engines/search_engines_switches.cc
+index 814f0aa0d3843..dc81bc3b96c85 100644
+--- a/components/search_engines/search_engines_switches.cc
++++ b/components/search_engines/search_engines_switches.cc
+@@ -36,7 +36,6 @@ COMPONENT_EXPORT(SEARCH_ENGINES_SWITCHES)
+ BASE_FEATURE(kSearchEngineChoiceTrigger,
+              "SearchEngineChoiceTrigger",
+              base::FEATURE_ENABLED_BY_DEFAULT);
+-SET_CROMITE_FEATURE_DISABLED(kSearchEngineChoiceTrigger);
+ 
+ COMPONENT_EXPORT(SEARCH_ENGINES_SWITCHES)
+ BASE_FEATURE(kSearchEngineChoiceAttribution,
+diff --git a/components/search_engines/template_url_service.cc b/components/search_engines/template_url_service.cc
+index e9e4bdfd26659..5c5de0fbf8546 100644
+--- a/components/search_engines/template_url_service.cc
++++ b/components/search_engines/template_url_service.cc
+@@ -708,15 +708,13 @@ TemplateURL* TemplateURLService::AddWithOverrides(
+     std::unique_ptr<TemplateURL> template_url,
+     const std::u16string& short_name,
+     const std::u16string& keyword,
+-    const std::string& url,
+-    const std::string& suggestions_url) {
++    const std::string& url) {
+   DCHECK(!short_name.empty());
+   DCHECK(!keyword.empty());
+   DCHECK(!url.empty());
+   template_url->data_.SetShortName(short_name);
+   template_url->data_.SetKeyword(keyword);
+   template_url->SetURL(url);
+-  template_url->data_.suggestions_url = suggestions_url;
+   return Add(std::move(template_url));
+ }
+ 
+@@ -920,8 +918,7 @@ void TemplateURLService::IncrementUsageCount(TemplateURL* url) {
+ void TemplateURLService::ResetTemplateURL(TemplateURL* url,
+                                           const std::u16string& title,
+                                           const std::u16string& keyword,
+-                                          const std::string& search_url,
+-                                          const std::string& suggestion_url) {
++                                          const std::string& search_url) {
+   DCHECK(!IsCreatedByExtension(url));
+   DCHECK(!keyword.empty());
+   DCHECK(!search_url.empty());
+@@ -933,7 +930,6 @@ void TemplateURLService::ResetTemplateURL(TemplateURL* url,
+     // The urls have changed, reset the favicon url.
+     data.favicon_url = GURL();
+   }
+-  data.suggestions_url = suggestion_url;
+   data.safe_for_autoreplace = false;
+   data.last_modified = clock_->Now();
+   data.is_active = TemplateURLData::ActiveStatus::kTrue;
+diff --git a/components/search_engines/template_url_service.h b/components/search_engines/template_url_service.h
+index 2a21f944a38bf..208163be6b90c 100644
+--- a/components/search_engines/template_url_service.h
++++ b/components/search_engines/template_url_service.h
+@@ -255,8 +255,7 @@ class TemplateURLService final : public WebDataServiceConsumer,
+   TemplateURL* AddWithOverrides(std::unique_ptr<TemplateURL> template_url,
+                                 const std::u16string& short_name,
+                                 const std::u16string& keyword,
+-                                const std::string& url,
+-                                const std::string& suggestion_url);
++                                const std::string& url);
+ 
+   // Removes the keyword from the model. This deletes the supplied TemplateURL.
+   // This fails if the supplied template_url is the default search provider.
+@@ -320,8 +319,7 @@ class TemplateURLService final : public WebDataServiceConsumer,
+   void ResetTemplateURL(TemplateURL* url,
+                         const std::u16string& title,
+                         const std::u16string& keyword,
+-                        const std::string& search_url,
+-                        const std::string& suggestion_url);
++                        const std::string& search_url);
+ 
+   // Sets the `is_active` field of the specified TemplateURL to `kTrue` or
+   // `kFalse`. Called when a user explicitly activates/deactivates the search
+diff --git a/content/browser/webui/web_ui_impl.cc b/content/browser/webui/web_ui_impl.cc
+index 4b77b3d315ff2..5437bfe1866cd 100644
+--- a/content/browser/webui/web_ui_impl.cc
++++ b/content/browser/webui/web_ui_impl.cc
+@@ -246,10 +246,6 @@ void WebUIImpl::RegisterMessageCallback(std::string_view message,
+   message_callbacks_.emplace(message, std::move(callback));
+ }
+ 
+-void WebUIImpl::DoNotCrashOnUnhandledMessage() {
+-  do_not_crash_on_unhandled_message_ = true;
+-}
+-
+ void WebUIImpl::ProcessWebUIMessage(const GURL& source_url,
+                                     const std::string& message,
+                                     base::Value::List args) {
+@@ -263,14 +259,8 @@ void WebUIImpl::ProcessWebUIMessage(const GURL& source_url,
+     return;
+   }
+ 
+-  if (!do_not_crash_on_unhandled_message_) {
+-    DUMP_WILL_BE_NOTREACHED() << "Unhandled chrome.send(\"" << message << "\", "
+-                              << args << "); from " << source_url;
+-  } else {
+-    DLOG(INFO)
+-        << "---Unhandled chrome.send(\"" << message << "\", " << args << "); from "
+-        << source_url;
+-  }
++  DUMP_WILL_BE_NOTREACHED() << "Unhandled chrome.send(\"" << message << "\", "
++                            << args << "); from " << source_url;
+ }
+ 
+ std::vector<std::unique_ptr<WebUIMessageHandler>>*
+diff --git a/content/browser/webui/web_ui_impl.h b/content/browser/webui/web_ui_impl.h
+index 331a57cb8815c..63b7680f68893 100644
+--- a/content/browser/webui/web_ui_impl.h
++++ b/content/browser/webui/web_ui_impl.h
+@@ -80,7 +80,6 @@ class CONTENT_EXPORT WebUIImpl : public WebUI, public mojom::WebUIHost {
+   void ProcessWebUIMessage(const GURL& source_url,
+                            const std::string& message,
+                            base::Value::List args) override;
+-  void DoNotCrashOnUnhandledMessage() override;
+   bool CanCallJavascript() override;
+   void CallJavascriptFunctionUnsafe(std::string_view function_name) override;
+   void CallJavascriptFunctionUnsafe(
+@@ -152,8 +151,6 @@ class CONTENT_EXPORT WebUIImpl : public WebUI, public mojom::WebUIHost {
+ 
+   std::unique_ptr<WebUIController> controller_;
+ 
+-  bool do_not_crash_on_unhandled_message_ = false;
+-
+   mojo::AssociatedRemote<mojom::WebUI> remote_;
+   mojo::AssociatedReceiver<mojom::WebUIHost> receiver_{this};
+ };
+diff --git a/content/public/browser/web_ui.h b/content/public/browser/web_ui.h
+index 824d0b905b48b..6d2eea53791c6 100644
+--- a/content/public/browser/web_ui.h
++++ b/content/public/browser/web_ui.h
+@@ -83,7 +83,6 @@ class CONTENT_EXPORT WebUI {
+ 
+   virtual void AddMessageHandler(
+       std::unique_ptr<WebUIMessageHandler> handler) = 0;
+-  virtual void DoNotCrashOnUnhandledMessage() = 0;
+ 
+   // Used by WebUIMessageHandlers. If the given message is already registered,
+   // the call has no effect.
+diff --git a/ui/base/template_expressions.cc b/ui/base/template_expressions.cc
+index e58a293edd4c1..7bf8a1561d4ec 100644
+--- a/ui/base/template_expressions.cc
++++ b/ui/base/template_expressions.cc
+@@ -14,7 +14,6 @@
+ #include "base/no_destructor.h"
+ #include "base/strings/escape.h"
+ #include "base/values.h"
+-#include "base/logging.h"
+ #include "build/chromeos_buildflags.h"
+ 
+ #if DCHECK_IS_ON()
+@@ -167,25 +166,11 @@ bool ReplaceTemplateExpressionsInternal(
+     std::string key(source.substr(current_pos, key_end - current_pos));
+     CHECK(!key.empty());
+ 
+-    std::string replacement;
+     auto value = replacements.find(key);
+-    if (value == replacements.end()) {
+-      bool check_notfound =
+-        replacements.find("check_notfound") == replacements.end();
+-      if (check_notfound) {
+-        CHECK(false) << "$i18n replacement key \"" << key
+-                     << "\" not found";
+-      }
+-      DLOG(INFO) << "---$i18n replacement key \"" << key
+-                 << "\" not found"
+-                 << " replacements=" << replacements.size()
+-                 << " is_javascript=" << is_javascript;
+-                 //<< " source=" << source;
+-      replacement = key;
+-    } else {
+-      replacement = value->second;
+-    }
++    CHECK(value != replacements.end()) << "$i18n replacement key \"" << key
++                                       << "\" not found";
+ 
++    std::string replacement = value->second;
+     if (is_javascript) {
+       // Run JS escaping first.
+       std::optional<char> last = formatted->empty()
+diff --git a/ui/webui/BUILD.gn b/ui/webui/BUILD.gn
+index 6a322666d850f..6775f9dcc8e68 100644
+--- a/ui/webui/BUILD.gn
++++ b/ui/webui/BUILD.gn
+@@ -28,14 +28,6 @@ static_library("webui") {
+     "//ui/webui/resources/js/metrics_reporter:mojo_bindings",
+   ]
+ 
+-  if (is_android) {
+-    public_deps += [
+-      "//ui/webui/resources/cr_components/customize_color_scheme_mode:mojom",
+-      "//ui/webui/resources/cr_components/customize_themes:mojom",
+-      "//ui/webui/resources/cr_components/theme_color_picker:mojom",
+-    ]
+-  }
+-
+   if (!is_android && !is_ios) {
+     public_deps += [
+       "//ui/webui/resources/cr_components/color_change_listener:mojom",
+diff --git a/ui/webui/resources/BUILD.gn b/ui/webui/resources/BUILD.gn
+index 66d4c4c227388..0694d55920329 100644
+--- a/ui/webui/resources/BUILD.gn
++++ b/ui/webui/resources/BUILD.gn
+@@ -79,16 +79,6 @@ generate_grd("build_grd") {
+       "$target_gen_dir/cr_components/managed_footnote/resources.grdp",
+       "$target_gen_dir/cr_components/most_visited/resources.grdp",
+     ]
+-    if (is_android) {
+-      public_deps -= [
+-        "cr_components/app_management:build_grdp",
+-        "cr_components/most_visited:build_grdp",
+-      ]
+-      grdp_files -= [
+-        "$target_gen_dir/cr_components/app_management/resources.grdp",
+-        "$target_gen_dir/cr_components/most_visited/resources.grdp",
+-      ]
+-    }
+ 
+     if (use_blink) {
+       if (use_nss_certs || chrome_root_store_cert_management_ui) {
+diff --git a/ui/webui/resources/cr_components/customize_color_scheme_mode/BUILD.gn b/ui/webui/resources/cr_components/customize_color_scheme_mode/BUILD.gn
+index 9a906780ff14a..19ca9d54ef223 100644
+--- a/ui/webui/resources/cr_components/customize_color_scheme_mode/BUILD.gn
++++ b/ui/webui/resources/cr_components/customize_color_scheme_mode/BUILD.gn
+@@ -5,7 +5,7 @@
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//ui/webui/resources/tools/build_webui.gni")
+ 
+-assert(!is_ios)
++assert(!is_android && !is_ios)
+ 
+ mojom("mojom") {
+   sources = [ "customize_color_scheme_mode.mojom" ]
+diff --git a/ui/webui/resources/cr_components/customize_themes/BUILD.gn b/ui/webui/resources/cr_components/customize_themes/BUILD.gn
+index ed7025572cb22..b0d94c5beaacd 100644
+--- a/ui/webui/resources/cr_components/customize_themes/BUILD.gn
++++ b/ui/webui/resources/cr_components/customize_themes/BUILD.gn
+@@ -5,7 +5,7 @@
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//ui/webui/resources/tools/build_webui.gni")
+ 
+-assert(!is_ios)
++assert(!is_android && !is_ios)
+ 
+ mojom("mojom") {
+   sources = [ "customize_themes.mojom" ]
+diff --git a/ui/webui/resources/cr_components/help_bubble/BUILD.gn b/ui/webui/resources/cr_components/help_bubble/BUILD.gn
+index 14244acb42c1c..a45bf1c86fb47 100644
+--- a/ui/webui/resources/cr_components/help_bubble/BUILD.gn
++++ b/ui/webui/resources/cr_components/help_bubble/BUILD.gn
+@@ -5,7 +5,7 @@
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//ui/webui/resources/tools/build_webui.gni")
+ 
+-assert(!is_ios)
++assert(!is_android && !is_ios)
+ 
+ mojom("mojo_bindings") {
+   sources = [ "help_bubble.mojom" ]
+diff --git a/ui/webui/resources/cr_components/theme_color_picker/BUILD.gn b/ui/webui/resources/cr_components/theme_color_picker/BUILD.gn
+index a7f0f40f48003..cbc045f5dd8a1 100644
+--- a/ui/webui/resources/cr_components/theme_color_picker/BUILD.gn
++++ b/ui/webui/resources/cr_components/theme_color_picker/BUILD.gn
+@@ -5,7 +5,7 @@
+ import("//mojo/public/tools/bindings/mojom.gni")
+ import("//ui/webui/resources/tools/build_webui.gni")
+ 
+-assert(!is_ios)
++assert(!is_android && !is_ios)
+ 
+ mojom("mojom") {
+   sources = [ "theme_color_picker.mojom" ]
+diff --git a/ui/webui/resources/cr_elements/cr_dialog/cr_dialog.css b/ui/webui/resources/cr_elements/cr_dialog/cr_dialog.css
+index a03c3405c473d..32edb13aef7c8 100644
+--- a/ui/webui/resources/cr_elements/cr_dialog/cr_dialog.css
++++ b/ui/webui/resources/cr_elements/cr_dialog/cr_dialog.css
+@@ -22,7 +22,7 @@ dialog {
+               0 16px 16px rgba(0, 0, 0, 0.24);
+   color: inherit;
+   max-height: initial;
+-  max-width: 95%;
++  max-width: initial;
+   overflow-y: hidden;
+   padding: 0;
+   position: absolute;
+diff --git a/ui/webui/resources/cr_elements/cr_shared_vars.css b/ui/webui/resources/cr_elements/cr_shared_vars.css
+index 04c016cffc817..72a597e945e8c 100644
+--- a/ui/webui/resources/cr_elements/cr_shared_vars.css
++++ b/ui/webui/resources/cr_elements/cr_shared_vars.css
+@@ -228,10 +228,6 @@ html {
+   --cr-form-field-label-line-height: 1;
+ }
+ 
+-html[chrome-android] {
+-  --cr-section-indent-width: 0px;
+-}
+-
+ html {
+   /* Colors: These variables should never be overridden and should only be used
+      as fallback values for shared cr_elements or in UIs that do not have
+diff --git a/ui/webui/resources/css/BUILD.gn b/ui/webui/resources/css/BUILD.gn
+index 50cfb3927ee55..e734c2497f9e8 100644
+--- a/ui/webui/resources/css/BUILD.gn
++++ b/ui/webui/resources/css/BUILD.gn
+@@ -5,7 +5,7 @@
+ import("//tools/grit/preprocess_if_expr.gni")
+ import("//ui/webui/resources/tools/generate_grd.gni")
+ 
+-include_polymer = !is_ios
++include_polymer = !is_android && !is_ios
+ 
+ preprocess_manifest = "preprocessed_manifest.json"
+ 
+diff --git a/ui/webui/resources/images/BUILD.gn b/ui/webui/resources/images/BUILD.gn
+index aa4394329803b..e10518e2536cf 100644
+--- a/ui/webui/resources/images/BUILD.gn
++++ b/ui/webui/resources/images/BUILD.gn
+@@ -48,7 +48,7 @@ generate_grd("build_grdp") {
+     "2x/select.png",
+   ]
+ 
+-  if (!is_ios) {
++  if (!is_android && !is_ios) {
+     input_files += [
+       "arrow_down.svg",
+       "arrow_right.svg",
+diff --git a/ui/webui/resources/include_polymer.gni b/ui/webui/resources/include_polymer.gni
+index 41b3b0118347a..52daa91cc2319 100644
+--- a/ui/webui/resources/include_polymer.gni
++++ b/ui/webui/resources/include_polymer.gni
+@@ -2,4 +2,4 @@
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
+ 
+-include_polymer = !is_ios
++include_polymer = !is_android && !is_ios
+diff --git a/ui/webui/resources/js/BUILD.gn b/ui/webui/resources/js/BUILD.gn
+index 2631389ad4c81..c6679f4f34e6b 100644
+--- a/ui/webui/resources/js/BUILD.gn
++++ b/ui/webui/resources/js/BUILD.gn
+@@ -5,7 +5,7 @@
+ import("//build/config/chromeos/ui_mode.gni")
+ import("../tools/build_webui.gni")
+ 
+-include_polymer = !is_ios
++include_polymer = !is_android && !is_ios
+ 
+ build_webui("build") {
+   grd_prefix = "webui_js"
+diff --git a/ui/webui/resources/js/load_time_data.ts b/ui/webui/resources/js/load_time_data.ts
+index 763c6727aa068..23574bae33126 100644
+--- a/ui/webui/resources/js/load_time_data.ts
++++ b/ui/webui/resources/js/load_time_data.ts
+@@ -22,7 +22,6 @@ interface LoadTimeDataRaw {
+ 
+ class LoadTimeData {
+   private data_: LoadTimeDataRaw|null = null;
+-  private is_android_: boolean = false;
+ 
+   /**
+    * Sets the backing object.
+@@ -34,8 +33,6 @@ class LoadTimeData {
+   set data(value: LoadTimeDataRaw) {
+     assert(!this.data_, 'Re-setting data.');
+     this.data_ = value;
+-    if (this.data_["chromeAndroid"] !== undefined && this.getValue("chromeAndroid") != "")
+-      this.is_android_ = true;
+   }
+ 
+   /**
+@@ -55,12 +52,7 @@ class LoadTimeData {
+   getValue(id: string): any {
+     assert(this.data_, 'No data. Did you remember to include strings.js?');
+     const value = this.data_[id];
+-    if (!this.is_android_)
+-      assert(typeof value !== 'undefined', 'Could not find value for ' + id);
+-    if(typeof value === 'undefined') {
+-      //console.log('Could not find value for ' + id);
+-      return id;
+-    }
++    assert(typeof value !== 'undefined', 'Could not find value for ' + id);
+     return value;
+   }
+ 
+@@ -160,12 +152,7 @@ class LoadTimeData {
+    */
+   getBoolean(id: string): boolean {
+     const value = this.getValue(id);
+-    if (!this.is_android_)
+-      assert(typeof value === 'boolean', `[${value}] (${id}) is not a boolean`);
+-    if(typeof value !== 'boolean') {
+-      //console.log(`[${value}] (${id}) is not a boolean`);
+-      return false;
+-    }
++    assert(typeof value === 'boolean', `[${value}] (${id}) is not a boolean`);
+     return value;
+   }
+ 
+-- 
+2.34.1
+


### PR DESCRIPTION
## Description

Adds support for trichrome apks

```sh
ninja -C out/arm64 trichrome_webview_64_32_apk trichrome_chrome_64_32_apk trichrome_library_64_32_apk
```

## All submissions

* [ ] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] Bromite can be built with these changes
* [ ] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [ ] patch description contains explanation of changes
* [ ] no unnecessary whitespace or unrelated changes
