### PR TITLE
Fix crash on first startup in EEA

### DIFF
--- a/build/patches/Add-search-engine.patch
+++ b/build/patches/Add-search-engine.patch
@@ -11,9 +11,12 @@ License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
  .../search_engine_choice/default_favicon.png  | Bin 0 -> 903 bytes
  ...search_engine_choice_scaled_resources.grdp |   1 +
  .../search_engines/prepopulated_engines.json  |  31 ++++++++++++++++++
+ .../search_engine_choice_utils.cc             |   5 +--
  .../search_engine_countries-inc.cc            |   3 ++
  .../search_engines/search_engine_type.h       |   5 +++
- 5 files changed, 40 insertions(+)
+ .../template_url_prepopulate_data.cc          |   1 -
+ .../template_url_prepopulate_data.h           |   7 ----
+ 8 files changed, 41 insertions(+), 12 deletions(-)
  create mode 100644 components/resources/default_100_percent/search_engine_choice/default_favicon.png
 
 diff --git a/components/resources/default_100_percent/search_engine_choice/default_favicon.png b/components/resources/default_100_percent/search_engine_choice/default_favicon.png
@@ -102,6 +105,21 @@ diff --git a/components/search_engines/prepopulated_engines.json b/components/se
      "mail_ru": {
        "name": "@MAIL.RU",
        "keyword": "mail.ru",
+diff --git a/components/search_engines/search_engine_choice/search_engine_choice_utils.cc b/components/search_engines/search_engine_choice/search_engine_choice_utils.cc
+--- a/components/search_engines/search_engine_choice/search_engine_choice_utils.cc
++++ b/components/search_engines/search_engine_choice/search_engine_choice_utils.cc
+@@ -226,10 +226,7 @@ void RecordChoiceScreenDefaultSearchProviderType(SearchEngineType engine_type) {
+ }
+ 
+ void RecordChoiceScreenSelectedIndex(int selected_engine_index) {
+-  base::UmaHistogramExactLinear(
+-      kSearchEngineChoiceScreenSelectedEngineIndexHistogram,
+-      selected_engine_index,
+-      TemplateURLPrepopulateData::kMaxEeaPrepopulatedEngines);
++  // do nothing in Cromite
+ }
+ 
+ void RecordChoiceScreenPositionsCountryMismatch(bool has_mismatch) {
 diff --git a/components/search_engines/search_engine_countries-inc.cc b/components/search_engines/search_engine_countries-inc.cc
 --- a/components/search_engines/search_engine_countries-inc.cc
 +++ b/components/search_engines/search_engine_countries-inc.cc
@@ -140,4 +158,33 @@ diff --git a/components/search_engines/search_engine_type.h b/components/search_
  // Enum to record the type of search engine a user used in keyword mode. This
  // should be kept aligned with the `OmniboxBuiltinEngineType` enum in enums.xml.
  // Entries should not be renumbered and numeric values should never be reused.
---
+diff --git a/components/search_engines/template_url_prepopulate_data.cc b/components/search_engines/template_url_prepopulate_data.cc
+--- a/components/search_engines/template_url_prepopulate_data.cc
++++ b/components/search_engines/template_url_prepopulate_data.cc
+@@ -80,7 +80,6 @@ GetPrepopulatedEnginesForEeaRegionCountries(int country_id,
+   generator.seed(profile_seed);
+   std::shuffle(t_urls.begin(), t_urls.end(), generator);
+ 
+-  CHECK_LE(t_urls.size(), kMaxEeaPrepopulatedEngines);
+   return t_urls;
+ }
+ 
+diff --git a/components/search_engines/template_url_prepopulate_data.h b/components/search_engines/template_url_prepopulate_data.h
+--- a/components/search_engines/template_url_prepopulate_data.h
++++ b/components/search_engines/template_url_prepopulate_data.h
+@@ -31,13 +31,6 @@ struct PrepopulatedEngine;
+ 
+ extern const int kMaxPrepopulatedEngineID;
+ 
+-// The maximum number of prepopulated search engines that can be returned in
+-// any of the EEA countries by `GetPrepopulatedEngines()`.
+-//
+-// Note: If this is increased, please also increase the declared variant count
+-// for the `Search.ChoiceScreenShowedEngineAt.Index{Index}` histogram.
+-inline constexpr size_t kMaxEeaPrepopulatedEngines = 8;
+-
+ // The maximum number of prepopulated search engines that can be returned in
+ // in the rest of the world by `GetPrepopulatedEngines()`.
+ inline constexpr size_t kMaxRowPrepopulatedEngines = 5;
+-- 
+


### PR DESCRIPTION
## Description

Solves an issue in which, with a system language whose country code is a country within the European Economic Area (extension of the EU), the browser may crash in template_url_prepopulate_data.cc with this error: `Check failed: t_urls.size() <= kMaxEeaPrepopulatedEngines (10 vs. 8)`

Discovered by a user in the CalyxOS Development channel. Does not appear to affect Cromite itself for some reason, but may impact forks.

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [x] Bromite can be built with these changes
* [x] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [x] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
