### PR TITLE
Include upstream Chromium fix for saved passwords

### DIFF
--- a/build/cromite_patches_list.txt
+++ b/build/cromite_patches_list.txt
@@ -301,6 +301,7 @@ Never-treat-Proguard-warnings-as-errors.patch
 Temp-disable-experimental-web-platform-features.patch
 Block-leakage-of-urls-in-sandbox-iframes.patch
 Fix-chromium-build-bugs.patch
+Check-USE_LOGIN_DATABASE_AS_BACKEND-before-removing-.patch
 
 # adblock patches
 eyeo-beta-118.0.5993.48-base.patch

--- a/build/patches/Check-USE_LOGIN_DATABASE_AS_BACKEND-before-removing-.patch
+++ b/build/patches/Check-USE_LOGIN_DATABASE_AS_BACKEND-before-removing-.patch
@@ -1,0 +1,52 @@
+From: Ioana Pandele <ioanap@chromium.org>
+Date: Thu, 9 Jan 2025 02:29:04 -0800
+Subject: Check USE_LOGIN_DATABASE_AS_BACKEND before removing the db
+
+Bug: 388451842
+Change-Id: Ic2f8e4f7d35b1c849480aae0a9327d8e08994d6b
+Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/6157381
+Reviewed-by: Vasilii Sukhanov <vasilii@chromium.org>
+Commit-Queue: Ioana Pandele <ioanap@chromium.org>
+Cr-Commit-Position: refs/heads/main@{#1404059}
+---
+ .../android/password_manager_android_util.cc                | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/chrome/browser/password_manager/android/password_manager_android_util.cc b/chrome/browser/password_manager/android/password_manager_android_util.cc
+--- a/chrome/browser/password_manager/android/password_manager_android_util.cc
++++ b/chrome/browser/password_manager/android/password_manager_android_util.cc
+@@ -247,6 +247,7 @@ void MaybeActivateSplitStoresAndLocalUpm(
+   }
+ }
+ 
++#if !BUILDFLAG(USE_LOGIN_DATABASE_AS_BACKEND)
+ // Called on startup from `MaybeDeactivateSplitStoresAndLocalUpm` to delete the
+ // login data files for users migrated to UPM. Must only be called if the value
+ // of the state pref `PasswordsUseUPMLocalAndSeparateStores` is `On` and there
+@@ -286,6 +287,7 @@ void MaybeDeleteLoginDataFiles(PrefService* prefs,
+   }
+   base::DeleteFile(account_db_journal_path);
+ }
++#endif  // !BUILDFLAG(USE_LOGIN_DATABASE_AS_BACKEND)
+ 
+ // Must only be called if the state pref is kOn or kOffAndMigrationPending, to
+ // set it to kOff if the user downgraded GmsCore. Any passwords saved to GmsCore
+@@ -318,13 +320,15 @@ void MaybeDeactivateSplitStoresAndLocalUpm(
+                         HasMinGmsVersion() ? ActivationError::kNone
+                                            : ActivationError::kOutdatedGmsCore);
+   if (HasMinGmsVersion()) {
+-    // GmsCore was not downgraded, no need to deactivate.
++#if !BUILDFLAG(USE_LOGIN_DATABASE_AS_BACKEND)
+     if (GetSplitStoresAndLocalUpmPrefValue(pref_service) == kOn &&
+         base::FeatureList::IsEnabled(
+             password_manager::features::
+                 kClearLoginDatabaseForAllMigratedUPMUsers)) {
+       MaybeDeleteLoginDataFiles(pref_service, login_db_directory);
+     }
++#endif  // !BUILDFLAG(USE_LOGIN_DATABASE_AS_BACKEND)
++    // GmsCore was not downgraded, no need to deactivate.
+     return;
+   }
+ 
+-- 
+


### PR DESCRIPTION
M132 changed the way the built-in login database is handled and included an unfortunate oversight that caused logins to be cleared, even with use_login_database_as_backend=true (already set via Restore-chrome-password-store.patch). This has been fixed upstream. That fix is included here manually for now.

## Description

Issue: #1735

## All submissions

I tested build and functionality successfully with CalyxOS Chromium but assume it can be built for Cromite, and should work.

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] Bromite can be built with these changes
* [ ] I have tested that the new change works as intended (AVD or physical device will do)

### Format

Unnecessary whitespace would be from upstream.

* [x] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
