### PR TITLE
fix typo in session permission

### DIFF
--- a/build/patches/Add-lifetime-options-for-permissions.patch
+++ b/build/patches/Add-lifetime-options-for-permissions.patch
@@ -21,7 +21,7 @@ There are 4 main areas affected to introduce the functionality:
   novel here.
   Therefore, `content_settings::GetConstraintSessionExpiration()` and `content_settings::IsConstraintSessionExpiration()`
   manage the lifetime modes of the session content-settings.
-  The modificaiton also adds the session pattern to the ContentSettingPatternSource so that it is available for the UI.
+  The modification also adds the session pattern to the ContentSettingPatternSource so that it is available for the UI.
 * components/permissions
   Lifetime support is added to the permissions; most of the changes are caused by the fact that it is necessary to report
   the value selected by the user from the Java UI managed by `components/browser_ui` up to
@@ -821,7 +821,7 @@ diff --git a/components/permissions/android/permissions_android_strings.grd b/co
  
 +      <!-- Session permissions -->
 +      <message name="IDS_SESSION_PERMISSIONS_TITLE" desc="Title for the session section in the permission request">
-+        Remeber my decision
++        Remember my decision
 +      </message>
 +      <message name="IDS_SESSION_PERMISSIONS_ONLY_THIS_THIS" desc="Message indicating that the permission is only for this time">
 +        Only this time


### PR DESCRIPTION
## Description

Simple typo fix in session permissions.

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [x] Bromite can be built with these changes
* [x] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
