### PR TITLE
[DOCS] Use the `%LOCALAPPDATA%` system environment variable to replace the default user profile path requiring manual username specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ ChromiumUpdateUrl=https://github.com/uazo/cromite/releases/latest/download/updat
 # Command line for Chromium (string):
 # note --user-data-dir= works better if path is absolute
 # See here: http://peter.sh/experiments/chromium-command-line-switches/
-ChromiumCommandLine=--user-data-dir="C:\Users\<my user>\AppData\Local\Cromite\User Data" --no-default-browser-check
+ChromiumCommandLine=--user-data-dir="%LOCALAPPDATA%\Cromite\User Data" --no-default-browser-check
 
 # to enable full logging in c:\temp\log.txt (daily rotate, no automatic deletion)
 # ChromiumCommandLine=--enable-logging --v=0 --log-file=C:\temp\log.txt --user-data-dir=".\User Data" --no-default-browser-check


### PR DESCRIPTION
## Description

*Please explain here what feature or bugfix these changes are addressing and why they should be included*

Use the `%LOCALAPPDATA%` system environment variable to replace the default user profile path requiring manual username specification.

Users can simply copy and paste `chrlauncher.ini` without changing it if not necessary.

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [x] Bromite can be built with these changes
* [x] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
