### PR TITLE
Enable CredentialManager APIs for all apps supporting passkeys

### DIFF
--- a/build/cromite_patches_list.txt
+++ b/build/cromite_patches_list.txt
@@ -305,6 +305,8 @@ Set-caret-blink-interval-to-default.patch
 Set-the-screen-frame-rate-to-60-Hz.patch
 Disable-Device-Attributes-API.patch
 Temp-disable-UseContextSnapshot.patch
+Enable-CredentialManager-APIs-for-all-apps-supporting-passkeys.patch
+Always-allow-platform-CredentialManager-calls-for-Android-15+.patch
 
 # temporary or wip patches
 Temp-PerformanceNavigationTiming-privacy-fix.patch

--- a/build/patches/Always-allow-platform-CredentialManager-calls-for-Android-15+.patch
+++ b/build/patches/Always-allow-platform-CredentialManager-calls-for-Android-15+.patch
@@ -1,0 +1,81 @@
+From: quh4gko8 <88831734+quh4gko8@users.noreply.github.com>
+Date: Wed, 26 Feb 2025 09:46:02 +0000
+Subject: Always allow platform CredentialManager calls for Android 15+
+
+Always allow platform CredentialManager calls for Android 15+
+
+License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
+---
+ .../webauthn/AuthenticatorImpl.java           | 22 +++++++++++++++++++
+ .../cred_man/CredManSupportProvider.java      |  6 +++++
+ 2 files changed, 28 insertions(+)
+
+diff --git a/components/webauthn/android/java/src/org/chromium/components/webauthn/AuthenticatorImpl.java b/components/webauthn/android/java/src/org/chromium/components/webauthn/AuthenticatorImpl.java
+index ec0d9c2fec25a..7186c51c212f0 100644
+--- a/components/webauthn/android/java/src/org/chromium/components/webauthn/AuthenticatorImpl.java
++++ b/components/webauthn/android/java/src/org/chromium/components/webauthn/AuthenticatorImpl.java
+@@ -169,6 +169,11 @@ public final class AuthenticatorImpl implements Authenticator, AuthenticationCon
+         mIsPaymentRequest = options.isPaymentCredentialCreation;
+         mMakeCredentialCallback = callback;
+         mIsOperationPending = true;
++        // START CHANGE downstream: Always route to Android 15's CredMan
++        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM) {
++            // Skip GMSCore checks.
++        } else
++        // END CHANGE downstream: Always route to Android 15's CredMan
+         if (!GmsCoreUtils.isWebauthnSupported()
+                 || (!isChrome(mWebContents) && !GmsCoreUtils.isResultReceiverSupported())) {
+             recordOutcomeEvent(MakeCredentialOutcome.OTHER_FAILURE);
+@@ -234,6 +239,11 @@ public final class AuthenticatorImpl implements Authenticator, AuthenticationCon
+         mIsConditionalRequest = options.mediation == Mediation.CONDITIONAL;
+         mIsImmediateRequest = options.mediation == Mediation.IMMEDIATE;
+ 
++        // START CHANGE downstream: Always route to Android 15's CredMan
++        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM) {
++            // Skip GMSCore checks.
++        } else
++        // END CHANGE downstream: Always route to Android 15's CredMan
+         if (!GmsCoreUtils.isWebauthnSupported()
+                 || (!isChrome(mWebContents) && !GmsCoreUtils.isResultReceiverSupported())
+                 || options.publicKey == null) {
+@@ -260,10 +270,22 @@ public final class AuthenticatorImpl implements Authenticator, AuthenticationCon
+     }
+ 
+     private boolean couldSupportConditionalMediation() {
++        // START CHANGE downstream: Always route to Android 15's CredMan
++        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM) {
++            // Skip GMSCore checks.
++            return true;
++        }
++        // END CHANGE downstream: Always route to Android 15's CredMan
+         return GmsCoreUtils.isWebauthnSupported() && isChrome(mWebContents);
+     }
+ 
+     private boolean couldSupportUvpaa() {
++        // START CHANGE downstream: Always route to Android 15's CredMan
++        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM) {
++            // Skip GMSCore checks.
++            return true;
++        }
++        // END CHANGE downstream: Always route to Android 15's CredMan
+         return GmsCoreUtils.isWebauthnSupported()
+                 && (isChrome(mWebContents) || GmsCoreUtils.isResultReceiverSupported());
+     }
+diff --git a/components/webauthn/android/java/src/org/chromium/components/webauthn/cred_man/CredManSupportProvider.java b/components/webauthn/android/java/src/org/chromium/components/webauthn/cred_man/CredManSupportProvider.java
+index b4ece05e803b0..d99563fe4e49b 100644
+--- a/components/webauthn/android/java/src/org/chromium/components/webauthn/cred_man/CredManSupportProvider.java
++++ b/components/webauthn/android/java/src/org/chromium/components/webauthn/cred_man/CredManSupportProvider.java
+@@ -60,6 +60,12 @@ public class CredManSupportProvider {
+             log(TAG, "Disabled because of Android version.");
+             return sCredManSupport;
+         }
++        // START CHANGE downstream: Always route to Android 15's CredMan
++        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.VANILLA_ICE_CREAM) {
++            log(TAG, "Skipped GMS checks because of Android version is 15 or newer");
++            // Skip GMSCore checks.
++        } else
++        // END CHANGE downstream: Always route to Android 15's CredMan
+         if (notSkippedBecauseInTests() && hasOldGmsVersion()) {
+             sCredManSupport = CredManSupport.DISABLED;
+             log(TAG, "Disabled because of old GMS version.");
+--

--- a/build/patches/Enable-CredentialManager-APIs-for-all-apps-supporting-passkeys.patch
+++ b/build/patches/Enable-CredentialManager-APIs-for-all-apps-supporting-passkeys.patch
@@ -1,0 +1,47 @@
+From: fgei <fgei@gmail.com>
+Date: Fri, 29 Mar 2024 13:26:23 +0000
+Subject: Enable CredentialManager APIs for all apps supporting passkeys
+
+Enables CredentialManager APIs for all apps supporting passkeys
+
+License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
+---
+ chrome/browser/webauthn/android/BUILD.gn          |  1 +
+ .../webauthn/CredManUiRecommenderImpl.java        | 15 +++++++++++++++
+ 2 files changed, 16 insertions(+)
+ create mode 100644 chrome/browser/webauthn/android/java/src/org/chromium/chrome/browser/webauthn/CredManUiRecommenderImpl.java
+
+diff --git a/chrome/browser/webauthn/android/BUILD.gn b/chrome/browser/webauthn/android/BUILD.gn
+index f9e1ff88e5a6f..da63602463cd4 100644
+--- a/chrome/browser/webauthn/android/BUILD.gn
++++ b/chrome/browser/webauthn/android/BUILD.gn
+@@ -12,6 +12,7 @@ android_library("java") {
+     "java/src/org/chromium/chrome/browser/webauthn/CableAuthenticatorModuleProvider.java",
+     "java/src/org/chromium/chrome/browser/webauthn/ChromeAuthenticatorConfirmationFactory.java",
+     "java/src/org/chromium/chrome/browser/webauthn/ChromeAuthenticatorFactory.java",
++    "java/src/org/chromium/chrome/browser/webauthn/CredManUiRecommenderImpl.java",
+   ]
+
+   deps = [
+diff --git a/chrome/browser/webauthn/android/java/src/org/chromium/chrome/browser/webauthn/CredManUiRecommenderImpl.java b/chrome/browser/webauthn/android/java/src/org/chromium/chrome/browser/webauthn/CredManUiRecommenderImpl.java
+new file mode 100644
+index 0000000000000..fcfc935c9218a
+--- /dev/null
++++ b/chrome/browser/webauthn/android/java/src/org/chromium/chrome/browser/webauthn/CredManUiRecommenderImpl.java
+@@ -0,0 +1,15 @@
++// Copyright 2024 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++package org.chromium.chrome.browser.webauthn;
++
++import org.chromium.build.annotations.ServiceImpl;
++import org.chromium.components.webauthn.cred_man.CredManUiRecommender;
++
++@ServiceImpl(CredManUiRecommender.class)
++public class CredManUiRecommenderImpl implements CredManUiRecommender {
++    @Override
++    public boolean recommendsCustomUi() {
++        return true; // Use the platform CredMan APIs if available.
++    }
++}
+--


### PR DESCRIPTION
## Description

Enable CredentialManager APIs for all apps supporting passkeys. I believe this will fix https://github.com/uazo/cromite/issues/329.

Original Source: https://github.com/GrapheneOS/Vanadium/blob/2c952098a599ef5ebd2b00012d5f3b254c3d5168/patches/0157-Enable-CredentialManager-APIs-for-all-apps-supportin.patch

I have not built/tested this myself.

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] Bromite can be built with these changes
* [ ] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [x] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
