### PR TITLE
Match nicovideo in background play js

### DIFF
--- a/build/userscripts/Allow-playing-videos-in-background.user.js
+++ b/build/userscripts/Allow-playing-videos-in-background.user.js
@@ -1,11 +1,12 @@
 // ==UserScript==
 // @name         Allow playing videos in background
-// @version      1.0.0
+// @version      1.1.0
 // @description  Allow playing youtube and vimeo videos in background in cromite. Original Javascript code by timdream and csagan5
 // @author       uazo
 // @match        https://*.youtube.com/*
 // @match        https://*.youtube-nocookie.com/*
 // @match        https://*.vimeo.com/*
+// @match        https://sp.nicovideo.jp/*
 // @grant        none
 // @run-at       document-start
 // ==/UserScript==


### PR DESCRIPTION
## Description

A video site based in Japan.

https://en.wikipedia.org/wiki/Niconico

All restrictions including the geo-blocking and background pause are limited to the mobile domain sp.nicovideo.jp.

## All submissions

* [X] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] Bromite can be built with these changes
* [ ] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [ ] patch description contains explanation of changes
* [ ] no unnecessary whitespace or unrelated changes
