### PR TITLE
Fix ::backdrop/dialog/popover not appearing in top layer

### DIFF
--- a/build/patches/Disable-CSS-blink-feature-support.patch
+++ b/build/patches/Disable-CSS-blink-feature-support.patch
@@ -1,26 +1,30 @@
 From: uazo <uazo@users.noreply.github.com>
 Date: Mon, 29 Jul 2024 06:48:25 +0000
-Subject: Disable CSS blink-feature support
+Subject: Disable CSS blink-feature support for author stylesheets
 
 the function is not currently exposed to websites but is only allowed for testing.
-disabled as it is an potentially advanced fingerprinting mechanism.
+disabled for author stylesheets as it is a potentially advanced fingerprinting mechanism.
+UA stylesheets (e.g. `dialog:modal { overlay: auto }`) still need blink-feature() to work.
 also fixed the possibility of using internal selectors for speculation rules.
 see https://chromium-review.googlesource.com/c/chromium/src/+/5540782
 
 License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
 ---
- .../blink/renderer/core/css/parser/css_supports_parser.cc       | 2 +-
+ .../blink/renderer/core/css/parser/css_supports_parser.cc       | 5 +++-
  .../renderer/core/speculation_rules/document_rule_predicate.cc  | 2 +-
- 2 files changed, 2 insertions(+), 2 deletions(-)
+ 2 files changed, 4 insertions(+), 2 deletions(-)
 
 diff --git a/third_party/blink/renderer/core/css/parser/css_supports_parser.cc b/third_party/blink/renderer/core/css/parser/css_supports_parser.cc
 --- a/third_party/blink/renderer/core/css/parser/css_supports_parser.cc
 +++ b/third_party/blink/renderer/core/css/parser/css_supports_parser.cc
-@@ -302,7 +302,7 @@ bool CSSSupportsParser::ConsumeBlinkFeatureFn(CSSParserTokenStream& stream) {
+@@ -302,7 +302,10 @@ bool CSSSupportsParser::ConsumeBlinkFeatureFn(CSSParserTokenStream& stream) {
              feature_name.Value().Utf8()) &&
          guard.Release()) {
        stream.ConsumeWhitespace();
 -      return true;
++      if (parser_.GetContext().Mode() == kUASheetMode) {
++        return true;
++      }
 +      return false;
      }
    }


### PR DESCRIPTION
:warning:  this is a poc, not tested yet. I am not familiar with this code base. feel free to take over and re-create this PR

## Description

Fix `::backdrop/dialog/popover` not appearing in top layer

`Disable-CSS-blink-feature-support.patch` made `ConsumeBlinkFeatureFn` always return false, which broke `@supports blink-feature(OverlayProperty)` in the UA stylesheet. Upstream Chromium M147 wrapped `dialog:modal { overlay: auto }` inside `@supports blink-feature(OverlayProperty)`, so this rule was never applied in Cromite, preventing dialog/popover from entering the top layer.

Fix: only block `blink-feature()` for author (website) stylesheets. UA stylesheets (browser built-in CSS like html.css) still need it.

Fixes #2918
Fixes #2895

## All submissions

* [x] there are no other open [Pull Requests](../../../pulls) for the same update/change
* [ ] Bromite can be built with these changes
* [ ] I have tested that the new change works as intended (AVD or physical device will do)

### Format

* [ ] patch subject and filename match (e.g. `Subject: Alternative cache (NIK-based)` -> `Alternative-cache-NIK-based.patch`)
* [x] patch description contains explanation of changes
* [x] no unnecessary whitespace or unrelated changes
