### PR TITLE
Keyboard geometry protection: fix crash on desktop

### DIFF
--- a/build/patches/Protect-keyboard-geometry-on-Android.patch
+++ b/build/patches/Protect-keyboard-geometry-on-Android.patch
@@ -31,7 +31,7 @@ License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
  .../sAndroidProtectedKeyboardGeometry.java    |   35 +
  ...otectedKeyboardGeometryContentSetting.java |   94 ++
  .../protected_keyboard_geometry.grdp          |   27 +
- .../protected_keyboard_geometry.inc           |   21 +
+ .../protected_keyboard_geometry.inc           |   23 +
  .../protected_keyboard_geometry.inc           |    1 +
  .../android/overscroll_controller_android.cc  |   40 +
  .../android/overscroll_controller_android.h   |   11 +
@@ -46,7 +46,7 @@ License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
  .../Android-Protected-Keyboard-Geometry.inc   |    3 +
  .../Android-Protected-Keyboard-Geometry.inc   |    2 +
  .../public/mojom/input/input_handler.mojom    |    4 +
- .../core/frame/local_frame_mojo_handler.cc    |    7 +-
+ .../core/frame/local_frame_mojo_handler.cc    |    6 +-
  .../renderer/core/frame/viewport_data.cc      |   13 +-
  .../blink/renderer/core/frame/viewport_data.h |    4 +-
  .../core/frame/web_frame_widget_impl.cc       |   20 +
@@ -65,7 +65,7 @@ License: GPL-2.0-or-later - https://spdx.org/licenses/GPL-2.0-or-later.html
  ui/android/overscroll_refresh.h               |    5 +
  ui/android/overscroll_refresh_handler.cc      |   24 +
  ui/android/overscroll_refresh_handler.h       |    5 +
- 44 files changed, 2429 insertions(+), 30 deletions(-)
+ 44 files changed, 2430 insertions(+), 30 deletions(-)
  create mode 100644 chrome/android/java/src/org/chromium/chrome/browser/compositor/ProtectedViewportScrollView.java
  create mode 100644 chrome/browser/flags/android/java/src/org/chromium/chrome/browser/flags/cromite/sAndroidProtectedKeyboardGeometry.java
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/impl/CromiteProtectedKeyboardGeometryContentSetting.java
@@ -2337,7 +2337,8 @@ diff --git a/components/content_settings/core/browser/bromite_content_settings/p
 new file mode 100644
 --- /dev/null
 +++ b/components/content_settings/core/browser/bromite_content_settings/protected_keyboard_geometry.inc
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,23 @@
++#if BUILDFLAG(IS_ANDROID)
 +  Register(ContentSettingsType::PROTECTED_KEYBOARD_GEOMETRY, "keyboard_size_protection", CONTENT_SETTING_ALLOW,
 +           WebsiteSettingsInfo::SYNCABLE,
 +           /*allowlisted_schemes=*/{},
@@ -2359,6 +2360,7 @@ new file mode 100644
 +    .set_allowed_exceptions_ui(IDS_SETTINGS_SITE_SETTINGS_PROTECTED_KEYBOARD_GEOMETRY_ALLOWED_EXCEPTIONS)
 +    .set_blocked_exceptions_ui(IDS_SETTINGS_SITE_SETTINGS_PROTECTED_KEYBOARD_GEOMETRY_BLOCKED_EXCEPTIONS)
 +    .set_mid_sentence_ui(IDS_SITE_SETTINGS_TYPE_PROTECTED_KEYBOARD_GEOMETRY_MID_SENTENCE);
++endif
 diff --git a/components/content_settings/core/common/bromite_content_settings/protected_keyboard_geometry.inc b/components/content_settings/core/common/bromite_content_settings/protected_keyboard_geometry.inc
 new file mode 100644
 --- /dev/null
@@ -2775,17 +2777,7 @@ diff --git a/third_party/blink/public/mojom/input/input_handler.mojom b/third_pa
    // on the outermost main frame. Can be used to reliably wait for a
    // ScrollFocusedEditableNodeIntoView to complete since that may create a
 diff --git a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
---- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
-+++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
-@@ -51,6 +51,7 @@
- #include "third_party/blink/renderer/core/frame/remote_frame_owner.h"
- #include "third_party/blink/renderer/core/frame/reporting_context.h"
- #include "third_party/blink/renderer/core/frame/savable_resources.h"
-+#include "third_party/blink/renderer/core/frame/web_frame_widget_impl.h"
- #include "third_party/blink/renderer/core/frame/web_local_frame_impl.h"
- #include "third_party/blink/renderer/core/fullscreen/fullscreen.h"
- #include "third_party/blink/renderer/core/html/html_element.h"
-@@ -577,7 +578,11 @@ void LocalFrameMojoHandler::NotifyVirtualKeyboardOverlayRect(
+@@ -578,7 +578,11 @@ void LocalFrameMojoHandler::NotifyVirtualKeyboardOverlayRect(
                          keyboard_rect.width() / scale_factor,
                          keyboard_rect.height() / scale_factor);
  

--- a/build/patches/Protect-keyboard-geometry-on-Android.patch
+++ b/build/patches/Protect-keyboard-geometry-on-Android.patch
@@ -2360,7 +2360,7 @@ new file mode 100644
 +    .set_allowed_exceptions_ui(IDS_SETTINGS_SITE_SETTINGS_PROTECTED_KEYBOARD_GEOMETRY_ALLOWED_EXCEPTIONS)
 +    .set_blocked_exceptions_ui(IDS_SETTINGS_SITE_SETTINGS_PROTECTED_KEYBOARD_GEOMETRY_BLOCKED_EXCEPTIONS)
 +    .set_mid_sentence_ui(IDS_SITE_SETTINGS_TYPE_PROTECTED_KEYBOARD_GEOMETRY_MID_SENTENCE);
-+endif
++#endif
 diff --git a/components/content_settings/core/common/bromite_content_settings/protected_keyboard_geometry.inc b/components/content_settings/core/common/bromite_content_settings/protected_keyboard_geometry.inc
 new file mode 100644
 --- /dev/null
@@ -2777,6 +2777,8 @@ diff --git a/third_party/blink/public/mojom/input/input_handler.mojom b/third_pa
    // on the outermost main frame. Can be used to reliably wait for a
    // ScrollFocusedEditableNodeIntoView to complete since that may create a
 diff --git a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
+--- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
++++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
 @@ -578,7 +578,11 @@ void LocalFrameMojoHandler::NotifyVirtualKeyboardOverlayRect(
                          keyboard_rect.width() / scale_factor,
                          keyboard_rect.height() / scale_factor);

--- a/build/patches/Viewport-Protection-flag.patch
+++ b/build/patches/Viewport-Protection-flag.patch
@@ -27,7 +27,7 @@ Require: Content-settings-infrastructure.patch
  .../renderer/core/frame/local_dom_window.cc   |  54 +++++++-
  .../blink/renderer/core/frame/local_frame.cc  |  17 ++-
  .../blink/renderer/core/frame/local_frame.h   |   6 +-
- .../core/frame/local_frame_mojo_handler.cc    |   5 +-
+ .../core/frame/local_frame_mojo_handler.cc    |   6 +-
  .../core/frame/screen_metrics_emulator.cc     |  18 ++-
  .../core/frame/screen_metrics_emulator.h      |  14 +++
  .../core/frame/web_frame_widget_impl.cc       |   9 ++
@@ -36,7 +36,7 @@ Require: Content-settings-infrastructure.patch
  third_party/blink/renderer/core/page/page.cc  | 117 ++++++++++++++++++
  third_party/blink/renderer/core/page/page.h   |  11 ++
  .../renderer/core/style/computed_style.h      |   6 +
- 27 files changed, 480 insertions(+), 20 deletions(-)
+ 27 files changed, 481 insertions(+), 20 deletions(-)
  create mode 100644 components/browser_ui/site_settings/android/java/src/org/chromium/components/browser_ui/site_settings/impl/BromiteViewportContentSetting.java
  create mode 100644 components/browser_ui/strings/bromite_content_settings/viewport.grdp
  create mode 100644 components/content_settings/core/browser/bromite_content_settings/viewport.inc
@@ -589,7 +589,15 @@ diff --git a/third_party/blink/renderer/core/frame/local_frame.h b/third_party/b
 diff --git a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
 --- a/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
 +++ b/third_party/blink/renderer/core/frame/local_frame_mojo_handler.cc
-@@ -568,7 +568,10 @@ void LocalFrameMojoHandler::NotifyVirtualKeyboardOverlayRect(
+@@ -51,6 +51,7 @@
+ #include "third_party/blink/renderer/core/frame/remote_frame_owner.h"
+ #include "third_party/blink/renderer/core/frame/reporting_context.h"
+ #include "third_party/blink/renderer/core/frame/savable_resources.h"
++#include "third_party/blink/renderer/core/frame/web_frame_widget_impl.h"
+ #include "third_party/blink/renderer/core/frame/web_local_frame_impl.h"
+ #include "third_party/blink/renderer/core/fullscreen/fullscreen.h"
+ #include "third_party/blink/renderer/core/html/html_element.h"
+@@ -568,7 +569,10 @@ void LocalFrameMojoHandler::NotifyVirtualKeyboardOverlayRect(
    const float window_to_viewport_factor =
        page->GetChromeClient().WindowToViewportScalar(&local_frame_root, 1.0f);
    const float zoom_factor = local_frame_root.LayoutZoomFactor();


### PR DESCRIPTION
* add missing buildflag guard for the content settings registration
* move header inc back to viewport protection patch as per the series order
